### PR TITLE
Skip first argument, it's the binary name.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -761,9 +761,11 @@ impl App {
 	pub fn get_matches(mut self) -> ArgMatches {
 		let mut matches = ArgMatches::new(self.name);
 
-		let args = env::args().collect::<Vec<_>>();	
+		let args = env::args().collect::<Vec<_>>();
+		let mut args_iter = args.into_iter();
+		let _ = args_iter.next();  // Program name
 
-		self.get_matches_from(&mut matches, &mut args.into_iter());
+		self.get_matches_from(&mut matches, &mut args_iter);
 
 		matches
 	}


### PR DESCRIPTION
However, I think Clap could make more clever use of it, using it as the
program name if the library user didn't provide one.