### PR TITLE
Remove assertion on multi args.

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -329,7 +329,6 @@ impl Arg {
     /// .multiple(true)
     /// # ).get_matches();
     pub fn multiple(mut self, multi: bool) -> Arg {
-        assert!(self.takes_value == false);
         assert!(self.index == None);
         self.multiple = multi;
         self


### PR DESCRIPTION
There's an assertion on line 322 of clap-rs/master that prevents any arg
where `multiple == true` from accepting any value. This commit only
deletes that assertion. It could cause any number of other problems; I
don't really know.

It does pass the tests, at least.

This is totally my first PR on github. :P