### PR TITLE
FOR REVIEW: `did-you-mean` for clap-rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 script:
   - travis-cargo build
   - travis-cargo test
+  - make -C clap-tests test
   - travis-cargo doc
 after_success:
   - travis-cargo --only beta doc-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: rust
 rust:
-- nightly
-- beta
+  - nightly
+  - beta
 before_script:
-- git clone --depth 1 https://github.com/kbknapp/travis-cargo
-- ln -s ./travis-cargo/travis-cargo.py tc
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
-- |
-  ./tc cargo build &&
-  ./tc cargo test &&
-  ./tc cargo doc
+  - travis-cargo build
+  - travis-cargo test
+  - travis-cargo doc
 after_success:
-- "./tc --only beta doc-upload"
+  - travis-cargo --only beta doc-upload
 env:
   global:
     secure: JLBlgHY6OEmhJ8woewNJHmuBokTNUv7/WvLkJGV8xk0t6bXBwSU0jNloXwlH7FiQTc4TccX0PumPDD4MrMgxIAVFPmmmlQOCmdpYP4tqZJ8xo189E5zk8lKF5OyaVYCs5SMmFC3cxCsKjfwGIexNu3ck5Uhwe9jI0tqgkgM3URA=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["argument", "command", "arg", "parser", "parse"]
 
 license = "MIT"
 
+[dependencies]
+strsim = "*"
+
 [features]
 default=[]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ keywords = ["argument", "command", "arg", "parser", "parse"]
 
 license = "MIT"
 
-[dependencies]
-strsim = "*"
-
 [features]
-default=[]
+default=["suggestions"]
+suggestions=["strsim"]
 
 # for building with nightly and unstable features
 unstable=[]
+
+[dependencies.strsim]
+version = "*"
+optional = true
+

--- a/clap-tests/Cargo.toml
+++ b/clap-tests/Cargo.toml
@@ -5,5 +5,4 @@ version = "0.0.1"
 authors = ["Kevin K. <kbknapp@gmail.com>"]
 
 [dependencies.clap]
-git = "https://github.com/kbknapp/clap-rs"
-branch = "master"
+path = ".."

--- a/clap-tests/Makefile
+++ b/clap-tests/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build test clean
 
 build:
-	# It may be that this project was never built, and no Cargo.lock exists.
-	# Thus it may be ignored
+	@# It may be that this project was never built, and no Cargo.lock exists.
+	@# Thus it may be ignored
 	cargo update 2>/dev/null || :
 	cargo build --release
 

--- a/clap-tests/Makefile
+++ b/clap-tests/Makefile
@@ -1,30 +1,14 @@
-THIS_MAKEFILE_PATH:=$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
-THIS_DIR:=$(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
-URL:=
-BRANCH:=
+.PHONY: build test clean
 
 build:
-	cargo update
+	# It may be that this project was never built, and no Cargo.lock exists.
+	# Thus it may be ignored
+	cargo update 2>/dev/null || :
 	cargo build --release
 
 test:
-	cd "$(THIS_DIR)"
-	cp Cargo.toml cargo.bak
-	@read -p "Fork URL: " URL; \
-	sed "/^git/c\git = \"$$URL\"" cargo.bak > Cargo.toml
-	@read -p "Branch [master]: " BRANCH; \
-	$(if $(strip $(BRANCH)), \
-		sed -i "/^branch/c\branch = \"master\"" Cargo.toml, \
-		sed -i "/^branch/c\branch = \"$$BRANCH\"" Cargo.toml)
-	(make clean) || (make clean && false)
-	cd "$(THIS_DIR)"
-	(make build) || (make clean && false)
-	cd "$(THIS_DIR)"
-	(./run_tests.py) || (make clean && false)
-	mv cargo.bak Cargo.toml
-	make clean
-
+	$(MAKE) build || ($(MAKE) clean && false)
+	./run_tests.py
 
 clean:
-	cd "$(THIS_DIR)"
 	cargo clean

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -45,6 +45,12 @@ USAGE:
 \tclaptests
 For more information try --help'''
 
+_pv_dym_usage = '''"slo" isn't a valid value for '--Option <option3>'
+\t[valid values: fast slow]. Did you mean "slow" ?
+USAGE:
+\tclaptests --Option <option3>
+For more information try --help'''
+
 _excluded = '''The argument '--flag' cannot be used with '-F'
 USAGE:
 \tclaptests [positional2] -F --long-option-2 <option2>
@@ -224,6 +230,7 @@ cmds = {'help short:         ': ['{} -h'.format(_bin), _help],
 		'mult_valsmo x1:     ': ['{} --multvalsmo some other'.format(_bin), _exact],
 		'F2(ss),O(s),P:      ': ['{} value -f -f -o some'.format(_bin), _f2op],
         'arg dym:            ': ['{} --optio=foo'.format(_bin), _arg_dym_usage],
+        'pv dym:             ': ['{} --Option slo'.format(_bin), _pv_dym_usage],
 		'O2(ll)P:            ': ['{} value --option some --option other'.format(_bin), _o2p],
 		'O2(l=l=)P:          ': ['{} value --option=some --option=other'.format(_bin), _o2p],
 		'O2(ss)P:            ': ['{} value -o some -o other'.format(_bin), _o2p],

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -40,6 +40,11 @@ USAGE:
 \tclaptests [POSITIONAL] [FLAGS] [OPTIONS] [SUBCOMMANDS]
 For more information try --help'''
 
+_arg_dym_usage = '''The argument --optio is unknown. Did you mean --option ?
+USAGE:
+\tclaptests [POSITIONAL] [FLAGS] [OPTIONS] [SUBCOMMANDS]
+For more information try --help'''
+
 _excluded = '''The argument '--flag' cannot be used with '-F'
 USAGE:
 \tclaptests [positional2] -F --long-option-2 <option2>
@@ -218,6 +223,7 @@ cmds = {'help short:         ': ['{} -h'.format(_bin), _help],
 		'mult_valsmo x2-1:   ': ['{} --multvalsmo some other --multvalsmo some'.format(_bin), _mult_vals_2m1],
 		'mult_valsmo x1:     ': ['{} --multvalsmo some other'.format(_bin), _exact],
 		'F2(ss),O(s),P:      ': ['{} value -f -f -o some'.format(_bin), _f2op],
+        'arg dym:            ': ['{} --optio=foo'.format(_bin), _arg_dym_usage],
 		'O2(ll)P:            ': ['{} value --option some --option other'.format(_bin), _o2p],
 		'O2(l=l=)P:          ': ['{} value --option=some --option=other'.format(_bin), _o2p],
 		'O2(ss)P:            ': ['{} value -o some -o other'.format(_bin), _o2p],

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -24,7 +24,7 @@ OPTIONS:
         --multvalsmo  <one> <two>        Tests mutliple values, not mult occs
     -o, --option  <opt>...               tests options
         --long-option-2  <option2>       tests long options with exclusions
-    -O <option3>                         tests options with specific value sets [values: fast slow]
+    -O, --Option  <option3>              tests options with specific value sets [values: fast slow]
 
 POSITIONAL ARGUMENTS:
     positional        tests positionals

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -40,9 +40,9 @@ USAGE:
 \tclaptests [POSITIONAL] [FLAGS] [OPTIONS] [SUBCOMMANDS]
 For more information try --help'''
 
-_arg_dym_usage = '''The argument --optio is unknown. Did you mean --option ?
+_arg_dym_usage = '''The argument --optio isn't valid. Did you mean --option ?
 USAGE:
-\tclaptests [POSITIONAL] [FLAGS] [OPTIONS] [SUBCOMMANDS]
+\tclaptests
 For more information try --help'''
 
 _excluded = '''The argument '--flag' cannot be used with '-F'

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -35,18 +35,21 @@ SUBCOMMANDS:
     help      Prints this message
     subcmd    tests subcommands'''
 
-_sc_dym_usage = '''Subcommand "subcm" is unknown. Did you mean "subcmd" ?
+_sc_dym_usage = '''Subcommand "subcm" isn't valid
+\tDid you mean "subcmd" ?
 USAGE:
 \tclaptests [POSITIONAL] [FLAGS] [OPTIONS] [SUBCOMMANDS]
 For more information try --help'''
 
-_arg_dym_usage = '''The argument --optio isn't valid. Did you mean --option ?
+_arg_dym_usage = '''The argument --optio isn't valid
+\tDid you mean --option ?
 USAGE:
 \tclaptests
 For more information try --help'''
 
 _pv_dym_usage = '''"slo" isn't a valid value for '--Option <option3>'
-\t[valid values: fast slow]. Did you mean "slow" ?
+\t[valid values: fast slow]
+\tDid you mean "slow" ?
 USAGE:
 \tclaptests --Option <option3>
 For more information try --help'''

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import sys
 import subprocess
 
@@ -260,7 +260,7 @@ cmds = {'help short:         ': ['{} -h'.format(_bin), _help],
 
 def pass_fail(name, check, good):
 	global failed
-	print(name, end='')
+	sys.stdout.write(name)
 	if check == good:
 		print('Pass')
 		return
@@ -270,9 +270,9 @@ def pass_fail(name, check, good):
 
 def main():
 	for cmd, cmd_v in cmds.items():
-		with subprocess.Popen(cmd_v[0], shell=True, stdout=subprocess.PIPE, universal_newlines=True) as proc:
-			out = proc.communicate()[0].strip()
-			pass_fail(cmd, out, cmd_v[1])
+		proc = subprocess.Popen(cmd_v[0], shell=True, stdout=subprocess.PIPE, universal_newlines=True)
+		out = proc.communicate()[0].strip()
+		pass_fail(cmd, out, cmd_v[1])
 	if failed:
 		print('One or more tests failed')
 		return 1

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -35,6 +35,11 @@ SUBCOMMANDS:
     help      Prints this message
     subcmd    tests subcommands'''
 
+_sc_dym_usage = '''Subcommand "subcm" is unknown. Did you mean "subcmd" ?
+USAGE:
+\tclaptests [POSITIONAL] [FLAGS] [OPTIONS] [SUBCOMMANDS]
+For more information try --help'''
+
 _excluded = '''The argument '--flag' cannot be used with '-F'
 USAGE:
 \tclaptests [positional2] -F --long-option-2 <option2>
@@ -220,6 +225,7 @@ cmds = {'help short:         ': ['{} -h'.format(_bin), _help],
 		'F(s),O(s),P:        ': ['{} value -f -o some'.format(_bin), _fop],
 		'F(l),O(l),P:        ': ['{} value --flag --option some'.format(_bin), _fop],
 		'F(l),O(l=),P:       ': ['{} value --flag --option=some'.format(_bin), _fop],
+        'sc dym:             ': ['{} subcm'.format(_bin), _sc_dym_usage],
 		'sc help short:      ': ['{} subcmd -h'.format(_bin), _schelp],
 		'sc help long:       ': ['{} subcmd --help'.format(_bin), _schelp],
 		'scF(l),O(l),P:      ': ['{} subcmd value --flag --option some'.format(_bin), _scfop],

--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import subprocess
 

--- a/clap-tests/src/main.rs
+++ b/clap-tests/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
                             Arg::from_usage("[flag2] -F 'tests flags with exclusions'").mutually_excludes("flag").requires("option2"),
                             Arg::from_usage("--long-option-2 [option2] 'tests long options with exclusions'").mutually_excludes("option").requires("positional2"),
                             Arg::from_usage("[positional2] 'tests positionals with exclusions'"),
-                            Arg::from_usage("-O [option3] 'tests options with specific value sets'").possible_values(&opt3_vals),
+                            Arg::from_usage("-O --Option [option3] 'tests options with specific value sets'").possible_values(&opt3_vals),
                             Arg::from_usage("[positional3]... 'tests positionals with specific values'").possible_values(&pos3_vals),
                             Arg::from_usage("--multvals [multvals] 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
                             Arg::from_usage("--multvalsmo [multvalsmo]... 'Tests mutliple values, not mult occs'").value_names(&m_val_names),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1788,26 +1788,25 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
             return None;
         }
 
-        match did_you_mean(arg, self.opts.values()
-                                         .filter_map(|v| 
-                                                if let Some(l) = v.long {Some(l)} else {None}
-                                          )
-                                         .collect::<Vec<_>>().iter()) {
-            Some(candidate_flag) => {
-                self.report_error(format!("The argument --{} is unknown. Did you mean --{} ?", 
-                                                                                arg, 
-                                                                                candidate_flag),
-                    true,
-                    true,
-                    None);
-            },
-            None => {
-                self.report_error(format!("The argument --{} isn't valid", arg),
-                    true,
-                    true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
-            }
-        }
+        let suffix =
+            match did_you_mean(arg, self.opts.values()
+                                             .filter_map(|v|
+                                                if let Some(ref l) = v.long {
+                                                    Some(l)
+                                                } else {
+                                                    None
+                                                }
+                                              )) {
+                Some(candidate_flag) => {
+                    format!(". Did you mean --{} ?", candidate_flag)
+                },
+                None => String::new()
+            };
+
+        self.report_error(format!("The argument --{} isn't valid{}", arg, suffix),
+            true,
+            true,
+            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
 
         unreachable!();
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,12 +11,14 @@ use args::{ ArgMatches, Arg, SubCommand, MatchedArg};
 use args::{ FlagBuilder, OptBuilder, PosBuilder};
 use args::ArgGroup;
 
+#[cfg(feature = "suggestions")]
 use strsim;
 
 /// Produces a string from a given list of possible values which is similar to 
 /// the passed in value `v` with a certain confidence.
 /// Thus in a list of possible values like ["foo", "bar"], the value "fop" will yield
 /// `Some("foo")`, whereas "blark" would yield `None`.
+#[cfg(feature = "suggestions")]
 fn did_you_mean<'a, T, I>(v: &str, possible_values: I) -> Option<&'a str> 
     where       T: AsRef<str> + 'a,
                 I: IntoIterator<Item=&'a T> {
@@ -33,6 +35,13 @@ fn did_you_mean<'a, T, I>(v: &str, possible_values: I) -> Option<&'a str>
         None => None,
         Some((_, candidate)) => Some(candidate),
     }
+}
+
+#[cfg(not(feature = "suggestions"))]
+fn did_you_mean<'a, T, I>(_: &str, _: I) -> Option<&'a str> 
+    where       T: AsRef<str> + 'a,
+                I: IntoIterator<Item=&'a T> {   
+    None
 }
 
 /// A helper to determine message formatting

--- a/src/app.rs
+++ b/src/app.rs
@@ -715,7 +715,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
         }
 
         if g_vec.is_empty() {
-            return args.iter().map(|s| s.to_owned()).collect::<Vec<_>>()
+            return args.iter().map(|s| s.to_owned()).collect()
         }
         return g_vec.iter().map(|g| self.get_group_members(g)).fold(vec![], |acc, v| acc + &v)
     }
@@ -739,7 +739,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
         }
 
         if g_vec.is_empty() {
-            return args.iter().map(|s| *s).collect::<Vec<_>>()
+            return args.iter().map(|s| *s).collect()
         }
         return g_vec.iter()
                     .map(|g| self.get_group_members_names(g))
@@ -1153,7 +1153,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
 
         let mut matches = ArgMatches::new();
 
-        let args = env::args().collect::<Vec<_>>();
+        let args: Vec<_> = env::args().collect();
         let mut it = args.into_iter();
         if let Some(name) = it.next() {
             let p = Path::new(&name[..]);
@@ -1234,7 +1234,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                                   }))),
                                         true,
                                         true,
-                                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                        Some(matches.args.keys().map(|k| *k).collect()));
                                 }
                             }
                         }
@@ -1250,7 +1250,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                             true,
                                             true,
                                             Some(
-                                                matches.args.keys().map(|k| *k).collect::<Vec<_>>()
+                                                matches.args.keys().map(|k| *k).collect()
                                             )
                                         );
                                     }
@@ -1296,7 +1296,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                             format!("Argument '{}' requires a value but none was supplied", o),
                             true,
                             true,
-                            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>() ) );
+                            Some(matches.args.keys().map(|k| *k).collect() ) );
                     }
                 }
             }
@@ -1337,7 +1337,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                             self.bin_name.clone().unwrap_or(self.name.clone())),
                         true,
                         true,
-                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                        Some(matches.args.keys().map(|k| *k).collect()));
                 }
                 // If we find that an argument requires a positiona, we need to update all the
                 // previous positionals too. This will denote where to start
@@ -1356,7 +1356,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                             }),
                             true,
                             true,
-                            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                            Some(matches.args.keys().map(|k| *k).collect()));
                     }
 
                     if let Some(ref p_vals) = p.possible_vals {
@@ -1372,7 +1372,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                               }))),
                                         true,
                                         true,
-                                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                        Some(matches.args.keys().map(|k| *k).collect()));
                             }
                         }
                     }
@@ -1388,7 +1388,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                             true,
                                             true,
                                             Some(matches.args.keys()
-                                                             .map(|k| *k).collect::<Vec<_>>()));
+                                                             .map(|k| *k).collect()));
                                     }
                                 }
                             }
@@ -1442,7 +1442,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                             self.bin_name.clone().unwrap_or(self.name.clone())),
                         true,
                         true,
-                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                        Some(matches.args.keys().map(|k| *k).collect()));
                 }
             }
         }
@@ -1459,7 +1459,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                 format!("Argument '{}' requires a value but none was supplied", o),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>() ) );
+                                Some(matches.args.keys().map(|k| *k).collect() ) );
                         }
                     }
                     else if !o.multiple {
@@ -1467,7 +1467,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                             format!("Argument '{}' requires a value but none was supplied", o),
                             true,
                             true,
-                            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>() ) );
+                            Some(matches.args.keys().map(|k| *k).collect() ) );
                     }
                     else {
                         self.report_error(format!("The following required arguments were not \
@@ -1479,7 +1479,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                 .fold(String::new(), |acc, s| acc + &format!("\t'{}'\n",s)[..])),
                             true,
                             true,
-                            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                            Some(matches.args.keys().map(|k| *k).collect()));
                     }
                 } else {
                     self.report_error(
@@ -1488,7 +1488,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                 self.positionals_name.get(a).unwrap()).unwrap())),
                             true,
                             true,
-                            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                            Some(matches.args.keys().map(|k| *k).collect()));
                 }
             }
             _ => {}
@@ -1508,7 +1508,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         .fold(String::new(), |acc, s| acc + &format!("\t'{}'\n",s)[..])),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
         }
 
@@ -1631,7 +1631,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         arg),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
             arg_val = Some(arg_vec[1].to_owned());
         }
@@ -1644,7 +1644,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                 matches.args.remove(v.name);
                 self.report_error(format!("The argument --{} cannot be used with one or more of \
                     the other specified arguments", arg),
-                    true, true, Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    true, true, Some(matches.args.keys().map(|k| *k).collect()));
             }
 
             if matches.args.contains_key(v.name) {
@@ -1653,7 +1653,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         does not support multiple values", arg),
                         true,
                         true,
-                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                        Some(matches.args.keys().map(|k| *k).collect()));
                 }
                 if let Some(ref p_vals) = v.possible_vals {
                     if let Some(ref av) = arg_val {
@@ -1669,7 +1669,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                               ),
                                     true,
                                     true,
-                                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                    Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                 }
@@ -1736,7 +1736,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                     }),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
 
             // Make sure this isn't one being added multiple times if it doesn't suppor it
@@ -1745,7 +1745,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                     not support multiple values", v),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
 
             let mut
@@ -1806,7 +1806,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
         self.report_error(format!("The argument --{} isn't valid{}", arg, suffix),
             true,
             true,
-            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+            Some(matches.args.keys().map(|k| *k).collect()));
 
         unreachable!();
     }
@@ -1822,7 +1822,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                     self.report_error(format!("The argument -{} isn't valid",arg),
                         true,
                         true,
-                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                        Some(matches.args.keys().map(|k| *k).collect()));
                 }
             }
             return None;
@@ -1852,7 +1852,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         }),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
 
             if matches.args.contains_key(v.name) {
@@ -1861,7 +1861,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         does not support multiple values", arg),
                         true,
                         true,
-                        Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                        Some(matches.args.keys().map(|k| *k).collect()));
                 }
             } else {
                 matches.args.insert(v.name, MatchedArg{
@@ -1899,7 +1899,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
         self.report_error(format!("The argument -{} isn't valid",arg_c),
             true,
             true,
-            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+            Some(matches.args.keys().map(|k| *k).collect()));
 
         unreachable!();
     }
@@ -1920,7 +1920,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         }),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
 
             // Make sure this isn't one being added multiple times if it doesn't suppor it
@@ -1929,7 +1929,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                         not support multiple values", arg),
                     true,
                     true,
-                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    Some(matches.args.keys().map(|k| *k).collect()));
             }
 
             let mut done = false;
@@ -1990,7 +1990,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                     }, match self.blacklisted_from(name, matches) {
                         Some(name) => format!("'{}'", name),
                         None       => "one or more of the other specified arguments".to_owned()
-                    }), true, true, Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                    }), true, true, Some(matches.args.keys().map(|k| *k).collect()));
             } else if self.groups.contains_key(name) {
                 for n in self.get_group_members_names(name) {
                     if matches.args.contains_key(n) {
@@ -2011,7 +2011,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                 }),
                             true,
                             true,
-                            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                            Some(matches.args.keys().map(|k| *k).collect()));
                     }
                 }
             }
@@ -2043,7 +2043,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                             ( vals.len() % num as usize) == 1) {"as"}else{"ere"}),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                     if let Some(num) = f.max_vals {
@@ -2056,7 +2056,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                     if vals.len() == 1 {"as"}else{"ere"}),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                     if let Some(num) = f.min_vals {
@@ -2069,7 +2069,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                     if vals.len() == 1 {"as"}else{"ere"}),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                 } else if let Some(f) = self.positionals_idx.get(
@@ -2084,7 +2084,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                     if vals.len() == 1 {"as"}else{"ere"}),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                     if let Some(num) = f.max_vals {
@@ -2097,7 +2097,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                     if vals.len() == 1 {"as"}else{"ere"}),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                     if let Some(num) = f.min_vals {
@@ -2110,7 +2110,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                     if vals.len() == 1 {"as"}else{"ere"}),
                                 true,
                                 true,
-                                Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+                                Some(matches.args.keys().map(|k| *k).collect()));
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1788,12 +1788,27 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
             return None;
         }
 
-        // Shouldn't reach here
-        self.report_error(format!("The argument --{} isn't valid", arg),
-            true,
-            true,
-            Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
-        // Can't reach here...
+        match did_you_mean(arg, self.opts.values()
+                                         .filter_map(|v| 
+                                                if let Some(l) = v.long {Some(l)} else {None}
+                                          )
+                                         .collect::<Vec<_>>().iter()) {
+            Some(candidate_flag) => {
+                self.report_error(format!("The argument --{} is unknown. Did you mean --{} ?", 
+                                                                                arg, 
+                                                                                candidate_flag),
+                    true,
+                    true,
+                    None);
+            },
+            None => {
+                self.report_error(format!("The argument --{} isn't valid", arg),
+                    true,
+                    true,
+                    Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));
+            }
+        }
+
         unreachable!();
     }
 
@@ -1882,7 +1897,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
         }
 
         // Didn't match a flag or option, must be invalid
-        self.report_error( format!("The argument -{} isn't valid",arg_c),
+        self.report_error(format!("The argument -{} isn't valid",arg_c),
             true,
             true,
             Some(matches.args.keys().map(|k| *k).collect::<Vec<_>>()));

--- a/src/app.rs
+++ b/src/app.rs
@@ -1231,7 +1231,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                                                     I: IntoIterator<Item=&'z T> {
         match did_you_mean(arg, values) {
                 Some(candidate) => {
-                    let mut suffix = ". Did you mean ".to_string();
+                    let mut suffix = "\n\tDid you mean ".to_string();
                     match style {
                         DidYouMeanMessageStyle::LongFlag => suffix.push_str("--"),
                         DidYouMeanMessageStyle::EnumValue => suffix.push('"'),
@@ -1371,7 +1371,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
 
                 if let Some(candidate_subcommand) = did_you_mean(&arg, self.subcommands.keys()) {
                     self.report_error(
-                        format!("Subcommand \"{}\" is unknown. Did you mean \"{}\" ?",
+                        format!("Subcommand \"{}\" isn't valid\n\tDid you mean \"{}\" ?",
                             arg,
                             candidate_subcommand),
                         true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@
 //!   - `Arg::new()` -> `Arg::with_name()`
 //!   - `Arg::mutually_excludes()` -> `Arg::conflicts_with()`
 //!   - `Arg::mutually_excludes_all()` -> `Arg::conflicts_with_all()`
+#[cfg(feature = "suggestions")]
 extern crate strsim;
 
 pub use args::{Arg, SubCommand, ArgMatches, ArgGroup};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@
 //!   - `Arg::new()` -> `Arg::with_name()`
 //!   - `Arg::mutually_excludes()` -> `Arg::conflicts_with()`
 //!   - `Arg::mutually_excludes_all()` -> `Arg::conflicts_with_all()`
+extern crate strsim;
 
 pub use args::{Arg, SubCommand, ArgMatches, ArgGroup};
 pub use app::App;


### PR DESCRIPTION
Now that *did you mean* was implemented for the parts under control of `google-apis-rs`, for completeness it should also be available for clap-rs. As done in `google-apis-rs`, suggestions should only be made above a certain confidence level, e.g. `foo` will not result in `did you mean 'baz'`.

This improvement involves the following parts:

* [x] **sub-command names**
    - `prog foo` results in `foo is not a valid subcommand. Did you mean 'fop'?`.
* [x]  **long flags and options**
   - `prog --heln` results in `--heln is not a valid option. Did you mean '--help'?`
   - `prog --debug-leve=1` results in `--debug-leve is not a valid option. Did you mean '--debug-level' ?`
   - Why not for short flags ? I think the input string should be more than one character to get a useful result.
   - *NOTE*: We do not provide the given arguments (i.e. `--debug-level=1`) in our suggestion as this is also currently not the case with the standard messages in that area. It might be worth a separate issue.
* [x] **possible values**
   - `prog --mode=foz` results in `'foz' is not a valid mode. Please choose one of 'foo' and 'baz'. Did you mean '--mode=foo' ?`
   - It only works for one item at a time.. Thus `prog --modi=foz` results in `--modi is not a valid option. Did you mean '--mode=foz'`. Thus it is not required to detect that the suggested flag has *possible values*, which allows this implementation to remain simple and 'stupid' in its first iteration.
* [x] **feature-gate these changes as `suggestions`**
    - should be enabled by default.

If the required confidence level is not reached, the output of the usage string will remain exactly as it was before.