### PR TITLE
fix: fixes a logic bug and allows setting Arg::number_of_values() < 2

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1685,6 +1685,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
         let mut subcmd_name: Option<String> = None;
         let mut needs_val_of: Option<&str> = None;
         let mut pos_counter = 1;
+        let mut val_counter = 0;
         while let Some(arg) = it.next() {
             let arg_slice = arg.as_ref();
             let mut skip = false;
@@ -1746,12 +1747,21 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                 skip = true;
                                 1
                             };
-                            if let Some(ref mut vals) = o.values {
+                            if let Some(ref vals) = o.values {
                                 let len = vals.len() as u8;
                                 if let Some(num) = opt.max_vals {
                                     if len != num { continue }
                                 } else if let Some(num) = opt.num_vals {
-                                    if len != num { continue }
+                                    if opt.multiple {
+                                        val_counter += 1;
+                                        if val_counter != num { 
+                                            continue 
+                                        } else {
+                                            val_counter = 0;
+                                        }
+                                    } else {
+                                        if len != num { continue }
+                                    }
                                 } else if !skip {
                                     continue
                                 }

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -645,8 +645,6 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// `.number_of_values(3)`, and this argument wouldn't be satisfied unless the user provided
     /// 3 and only 3 values.
     ///
-    /// **NOTE:** `qty` must be > 1
-    ///
     /// **NOTE:** Does *not* require `.multiple(true)` to be set. Setting `.multiple(true)` would
     /// allow `-f <file> <file> <file> -f <file> <file> <file>` where as *not* setting
     /// `.multiple(true)` would only allow one occurrence of this argument.
@@ -661,11 +659,6 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// .number_of_values(3)
     /// # ).get_matches();
     pub fn number_of_values(mut self, qty: u8) -> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
-        if qty < 2 {
-            panic!("Arguments with number_of_values(qty) qty must be > 1. Prefer \
-                takes_value(true) for arguments with only one value, or flags for arguments \
-                with 0 values.");
-        }
         self.num_vals = Some(qty);
         self
     }


### PR DESCRIPTION
Allows setting `Arg::number_of_values(qty)` where `qty` < 2. This allows
things such as `Arg::number_of_values(1)` in conjuction with
`Arg::multiple(true)` which would make invoking the program like this
`myprog --opt val --opt val` legal, but `myprog --opt val1 val2`
illegal.

Closes #161