### PR TITLE
Replaced some application settings with enum variants

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -54,7 +54,7 @@ enum DidYouMeanMessageStyle {
 }
 
 /// Some application options 
-pub enum AppOptions {
+pub enum AppSettings {
     /// Allows subcommands to override all requirements of the parent (this command). For example
     /// if you had a subcommand or even top level application which had a required arguments that
     /// are only required as long as there is no subcommand present.
@@ -64,12 +64,12 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, AppOptions};
+    /// # use clap::{App, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::SubcommandsNagateReqs)
+    ///     .setting(AppSettings::SubcommandsNegateReqs)
     /// # ;
     /// ```
-    SubcommandsNagateReqs,
+    SubcommandsNegateReqs,
     /// Allows specifying that if no subcommand is present at runtime, error and exit gracefully
     ///
     /// **NOTE:** This defaults to false (subcommands do *not* need to be present)
@@ -77,9 +77,9 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, AppOptions};
+    /// # use clap::{App, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::SubcommandRequired)
+    ///     .setting(AppSettings::SubcommandRequired)
     /// # ;
     /// ```
     SubcommandRequired,
@@ -91,9 +91,9 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, AppOptions};
+    /// # use clap::{App, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::ArgRequiredElseHelp)
+    ///     .setting(AppSettings::ArgRequiredElseHelp)
     /// # ;
     /// ```
     ArgRequiredElseHelp,
@@ -106,10 +106,10 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg, SubCommand, AppOptions};
+    /// # use clap::{App, Arg, SubCommand, AppSettings};
     /// App::new("myprog")
     ///     .version("v1.1")
-    ///     .setting(AppOptions::GlobalVersion)
+    ///     .setting(AppSettings::GlobalVersion)
     ///     .subcommand(SubCommand::with_name("test"))
     ///     .get_matches();
     /// // running `myprog test --version` will display
@@ -126,10 +126,10 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg, SubCommand, AppOptions};
+    /// # use clap::{App, Arg, SubCommand, AppSettings};
     /// App::new("myprog")
     ///     .version("v1.1")
-    ///     .setting(AppOptions::VersionlessSubcommands)
+    ///     .setting(AppSettings::VersionlessSubcommands)
     ///     .subcommand(SubCommand::with_name("test"))
     ///     .get_matches();
     /// // running `myprog test --version` will display unknown argument error
@@ -144,9 +144,9 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg, SubCommand, AppOptions};
+    /// # use clap::{App, Arg, SubCommand, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::UnifiedHelpMessage)
+    ///     .setting(AppSettings::UnifiedHelpMessage)
     ///     .get_matches();
     /// // running `myprog --help` will display a unified "docopt" or "getopts" style help message
     /// ```
@@ -166,9 +166,9 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg, AppOptions};
+    /// # use clap::{App, Arg, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::WaitOnError)
+    ///     .setting(AppSettings::WaitOnError)
     /// # ;
     /// ```
     WaitOnError,
@@ -185,9 +185,9 @@ pub enum AppOptions {
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg, AppOptions};
+    /// # use clap::{App, Arg, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::SubcommandRequiredElseHelp)
+    ///     .setting(AppSettings::SubcommandRequiredElseHelp)
     /// # ;
     /// ```
     SubcommandRequiredElseHelp,
@@ -692,22 +692,22 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg, AppOptions};
+    /// # use clap::{App, Arg, AppSettings};
     /// App::new("myprog")
-    ///     .setting(AppOptions::SubcommandRequired)
-    ///     .setting(AppOptions::WaitOnError)
+    ///     .setting(AppSettings::SubcommandRequired)
+    ///     .setting(AppSettings::WaitOnError)
     /// # ;
     /// ```
-    pub fn setting(mut self, option: AppOptions) -> Self {
+    pub fn setting(mut self, option: AppSettings) -> Self {
         match option {
-            AppOptions::SubcommandsNagateReqs      => self.subcmds_neg_reqs = true,
-            AppOptions::SubcommandRequired         => self.no_sc_error = true,
-            AppOptions::ArgRequiredElseHelp        => self.help_on_no_args = true,
-            AppOptions::GlobalVersion              => self.global_ver = true,
-            AppOptions::VersionlessSubcommands     => self.versionless_scs = Some(true),
-            AppOptions::UnifiedHelpMessage         => self.unified_help = true,
-            AppOptions::WaitOnError                => self.wait_on_error = true,
-            AppOptions::SubcommandRequiredElseHelp => self.help_on_no_sc = true,
+            AppSettings::SubcommandsNegateReqs      => self.subcmds_neg_reqs = true,
+            AppSettings::SubcommandRequired         => self.no_sc_error = true,
+            AppSettings::ArgRequiredElseHelp        => self.help_on_no_args = true,
+            AppSettings::GlobalVersion              => self.global_ver = true,
+            AppSettings::VersionlessSubcommands     => self.versionless_scs = Some(true),
+            AppSettings::UnifiedHelpMessage         => self.unified_help = true,
+            AppSettings::WaitOnError                => self.wait_on_error = true,
+            AppSettings::SubcommandRequiredElseHelp => self.help_on_no_sc = true,
         }
         self
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,13 +55,141 @@ enum DidYouMeanMessageStyle {
 
 /// Some application options 
 pub enum AppOptions {
+    /// Allows subcommands to override all requirements of the parent (this command). For example
+    /// if you had a subcommand or even top level application which had a required arguments that
+    /// are only required as long as there is no subcommand present.
+    ///
+    /// **NOTE:** This defaults to false (using subcommand does *not* negate requirements)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, AppOptions};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::SubcommandsNagateReqs)
+    /// # ;
+    /// ```
     SubcommandsNagateReqs,
+    /// Allows specifying that if no subcommand is present at runtime, error and exit gracefully
+    ///
+    /// **NOTE:** This defaults to false (subcommands do *not* need to be present)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, AppOptions};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::SubcommandRequired)
+    /// # ;
+    /// ```
     SubcommandRequired,
+    /// Specifies that the help text sould be displayed (and then exit gracefully), if no
+    /// arguments are present at runtime (i.e. an empty run such as, `$ myprog`.
+    ///
+    /// **NOTE:** Subcommands count as arguments
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, AppOptions};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::ArgRequiredElseHelp)
+    /// # ;
+    /// ```
     ArgRequiredElseHelp,
+    /// Uses version of the current command for all subcommands. (Defaults to false; subcommands
+    /// have independant version strings)
+    ///
+    /// **NOTE:** The version for the current command and this setting must be set **prior** to
+    /// adding any subcommands
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, SubCommand, AppOptions};
+    /// App::new("myprog")
+    ///     .version("v1.1")
+    ///     .setting(AppOptions::GlobalVersion)
+    ///     .subcommand(SubCommand::with_name("test"))
+    ///     .get_matches();
+    /// // running `myprog test --version` will display
+    /// // "myprog-test v1.1"
+    /// ```
     GlobalVersion,
+    /// Disables `-V` and `--version` for all subcommands (Defaults to false; subcommands have
+    /// version flags)
+    ///
+    /// **NOTE:** This setting must be set **prior** adding any subcommands
+    ///
+    /// **NOTE:** Do not set this value to false, it will have undesired results!
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, SubCommand, AppOptions};
+    /// App::new("myprog")
+    ///     .version("v1.1")
+    ///     .setting(AppOptions::VersionlessSubcommands)
+    ///     .subcommand(SubCommand::with_name("test"))
+    ///     .get_matches();
+    /// // running `myprog test --version` will display unknown argument error
+    /// ```
     VersionlessSubcommands,
+    /// By default the auto-generated help message groups flags, options, and positional arguments
+    /// separately. This setting disable that and groups flags and options together presenting a
+    /// more unified help message (a la getopts or docopt style).
+    ///
+    /// **NOTE:** This setting is cosmetic only and does not affect any functionality.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, SubCommand, AppOptions};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::UnifiedHelpMessage)
+    ///     .get_matches();
+    /// // running `myprog --help` will display a unified "docopt" or "getopts" style help message
+    /// ```
     UnifiedHelpMessage,
+    /// Will display a message "Press [ENTER]/[RETURN] to continue..." and wait user before
+    /// exiting
+    ///
+    /// This is most useful when writing an application which is run from a GUI shortcut, or on
+    /// Windows where a user tries to open the binary by double-clicking instead of using the
+    /// command line (i.e. set `.arg_required_else_help(true)` and `.wait_on_error(true)` to
+    /// display the help in such a case).
+    ///
+    /// **NOTE:** This setting is **not** recursive with subcommands, meaning if you wish this
+    /// behavior for all subcommands, you must set this on each command (needing this is extremely
+    /// rare)
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppOptions};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::WaitOnError)
+    /// # ;
+    /// ```
     WaitOnError,
+    /// Specifies that the help text sould be displayed (and then exit gracefully), if no
+    /// subcommands are present at runtime (i.e. an empty run such as, `$ myprog`.
+    ///
+    /// **NOTE:** This should *not* be used with `.subcommand_required()` as they do the same
+    /// thing, except one prints the help text, and one prints an error.
+    ///
+    /// **NOTE:** If the user specifies arguments at runtime, but no subcommand the help text will
+    /// still be displayed and exit. If this is *not* the desired result, consider using
+    /// `.arg_required_else_help()`
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppOptions};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::SubcommandRequiredElseHelp)
+    /// # ;
+    /// ```
     SubcommandRequiredElseHelp,
 }
 
@@ -559,13 +687,15 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
 
     /// Enables Application Option, passed as argument
     ///
+    /// 
+    ///
     /// # Example
     ///
     /// ```no_run
-    /// # use clap::{App, Arg};
+    /// # use clap::{App, Arg, AppOptions};
     /// App::new("myprog")
     ///     .setting(AppOptions::SubcommandRequired)
-    ///		.setting(AppOptions::WaitOnError)
+    ///     .setting(AppOptions::WaitOnError)
     /// # ;
     /// ```
     pub fn setting(mut self, option: AppOptions) -> Self {

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,6 +53,18 @@ enum DidYouMeanMessageStyle {
     EnumValue,
 }
 
+/// Some application options 
+pub enum AppOptions {
+    SubcommandsNagateReqs,
+    SubcommandRequired,
+    ArgRequiredElseHelp,
+    GlobalVersion,
+    VersionlessSubcommands,
+    UnifiedHelpMessage,
+    WaitOnError,
+    SubcommandRequiredElseHelp,
+}
+
 /// Used to create a representation of a command line program and all possible command line
 /// arguments.
 ///
@@ -542,6 +554,31 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// ```
     pub fn subcommand_required_else_help(mut self, tf: bool) -> Self {
         self.help_on_no_sc = tf;
+        self
+    }
+
+    /// Enables Application Option, passed as argument
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .setting(AppOptions::SubcommandRequired)
+    ///		.setting(AppOptions::WaitOnError)
+    /// # ;
+    /// ```
+    pub fn setting(mut self, option: AppOptions) -> Self {
+        match option {
+            AppOptions::SubcommandsNagateReqs      => self.subcmds_neg_reqs = true,
+            AppOptions::SubcommandRequired         => self.no_sc_error = true,
+            AppOptions::ArgRequiredElseHelp        => self.help_on_no_args = true,
+            AppOptions::GlobalVersion              => self.global_ver = true,
+            AppOptions::VersionlessSubcommands     => self.versionless_scs = Some(true),
+            AppOptions::UnifiedHelpMessage         => self.unified_help = true,
+            AppOptions::WaitOnError                => self.wait_on_error = true,
+            AppOptions::SubcommandRequiredElseHelp => self.help_on_no_sc = true,
+        }
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ extern crate strsim;
 extern crate ansi_term;
 
 pub use args::{Arg, SubCommand, ArgMatches, ArgGroup};
-pub use app::{App, AppOptions};
+pub use app::{App, AppSettings};
 pub use fmt::Format;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ extern crate strsim;
 extern crate ansi_term;
 
 pub use args::{Arg, SubCommand, ArgMatches, ArgGroup};
-pub use app::App;
+pub use app::{App, AppOptions};
 pub use fmt::Format;
 
 #[macro_use]


### PR DESCRIPTION
Feature for #169. 
For now I`ve done as in issue asked.
How is better to change docs and *setting* method example? Maybe mark somehow methods as *deprecated*? How about *info* method to string-info settings?