### PR TITLE
 Fixed confusing error message

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -280,7 +280,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
         }
 
         Arg {
-            name: name.unwrap(),
+            name: name.unwrap_or_else(|| panic!("Missing flag name in \"{}\", check from_usage call", u)),
             short: short,
             long: long,
             help: help,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1242,4 +1242,17 @@ mod tests {
         assert!(m.is_present("debug"));
     }
 
+    #[test]
+    #[should_panic]
+    fn short_flag_misspel() {
+        App::new("short_flag")
+            .arg(Arg::from_usage("-f1, --flag 'some flag'"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn short_flag_name_missing() {
+        App::new("short_flag")
+            .arg(Arg::from_usage("-f 'some flag'"));
+    }
 }

--- a/src/usageparser.rs
+++ b/src/usageparser.rs
@@ -124,8 +124,11 @@ impl<'u> Iterator for UsageParser<'u> {
                     self.e += 1;
                     continue
                 },
-                _  => {
+                None => {
                     return None
+                },
+                Some(c) => {
+                    panic!("Usage parser error, unexpected \"{}\" at \"{}\", check from_usage call", c, self.usage);
                 }
             }
         }


### PR DESCRIPTION
PR to resolve #179.
Now 
```
App::new("short_flag")
            .arg(Arg::from_usage("-f1, --flag 'some flag'"));
```
will panic with:
> Usage parser error, unexpected "1" at "-f1, --flag 'some flag'", check from_usage call"

And 
```
App::new("short_flag")
            .arg(Arg::from_usage("-f 'some flag'"));
```
will panic with:
> Missing flag name in "-f 'some flag'", check from_usage call