### PR TITLE
tests(benchmark): Add build and clean parse benchmarks

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -7,75 +7,49 @@ use clap::{App, Arg, SubCommand};
 
 use test::Bencher;
 
-#[bench]
-fn build(b: &mut Bencher) {
-    let m_val_names = ["one", "two"];
-    let args = "-o --option=[opt]... 'tests options'
-                            [positional] 'tests positionals'";
-    let opt3_vals = ["fast", "slow"];
-    let pos3_vals = ["vi", "emacs"];
+static M_VAL_NAMES: [&'static str; 2] = ["one", "two"];
+static ARGS: &'static str = "-o --option=[opt]... 'tests options'
+                             [positional] 'tests positionals'";
+static OPT3_VALS: [&'static str; 2] = ["fast", "slow"];
+static POS3_VALS: [&'static str; 2] = ["vi", "emacs"];
 
-    b.iter(|| App::new("claptests")
-                    // Test version from Cargo.toml
-                    .version("0.1")
-                    .about("tests clap library")
-                    .author("Kevin K. <kbknapp@gmail.com>")
-                    .args_from_usage(args)
-                    .arg(Arg::from_usage("-f --flag... 'tests flags'")
-                                 .global(true))
-                    .args(vec![
-                              Arg::from_usage("[flag2] -F 'tests flags with exclusions'").conflicts_with("flag").requires("option2"),
-                              Arg::from_usage("--long-option-2 [option2] 'tests long options with exclusions'").conflicts_with("option").requires("positional2"),
-                              Arg::from_usage("[positional2] 'tests positionals with exclusions'"),
-                              Arg::from_usage("-O --Option [option3] 'tests options with specific value sets'").possible_values(&opt3_vals),
-                              Arg::from_usage("[positional3]... 'tests positionals with specific values'").possible_values(&pos3_vals),
-                              Arg::from_usage("--multvals [multvals] 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
-                              Arg::from_usage("--multvalsmo [multvalsmo]... 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
-                              Arg::from_usage("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
-                              Arg::from_usage("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3)
-                        ])
-                    .subcommand(SubCommand::with_name("subcmd")
-                                            .about("tests subcommands")
-                                            .version("0.1")
-                                            .author("Kevin K. <kbknapp@gmail.com>")
-                                            .arg_from_usage("-o --option [scoption]... 'tests options'")
-                                            .arg_from_usage("[scpositional] 'tests positionals'")));
+macro_rules! create_app {
+    () => ({
+        App::new("claptests")
+                .version("0.1")
+                .about("tests clap library")
+                .author("Kevin K. <kbknapp@gmail.com>")
+                .args_from_usage(ARGS)
+                .arg(Arg::from_usage("-f --flag... 'tests flags'")
+                             .global(true))
+                .args(vec![
+                          Arg::from_usage("[flag2] -F 'tests flags with exclusions'").conflicts_with("flag").requires("option2"),
+                          Arg::from_usage("--long-option-2 [option2] 'tests long options with exclusions'").conflicts_with("option").requires("positional2"),
+                          Arg::from_usage("[positional2] 'tests positionals with exclusions'"),
+                          Arg::from_usage("-O --Option [option3] 'tests options with specific value sets'").possible_values(&OPT3_VALS),
+                          Arg::from_usage("[positional3]... 'tests positionals with specific values'").possible_values(&POS3_VALS),
+                          Arg::from_usage("--multvals [multvals] 'Tests mutliple values, not mult occs'").value_names(&M_VAL_NAMES),
+                          Arg::from_usage("--multvalsmo [multvalsmo]... 'Tests mutliple values, not mult occs'").value_names(&M_VAL_NAMES),
+                          Arg::from_usage("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
+                          Arg::from_usage("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3)
+                    ])
+                .subcommand(SubCommand::with_name("subcmd")
+                                        .about("tests subcommands")
+                                        .version("0.1")
+                                        .author("Kevin K. <kbknapp@gmail.com>")
+                                        .arg_from_usage("-o --option [scoption]... 'tests options'")
+                                        .arg_from_usage("[scpositional] 'tests positionals'"))
+    })
 }
 
+#[bench]
+fn build_app(b: &mut Bencher) {
+
+    b.iter(|| create_app!());
+}
 
 #[bench]
 fn parse_clean(b: &mut Bencher) {
-    let m_val_names = ["one", "two"];
-    let args = "-o --option=[opt]... 'tests options'
-                            [positional] 'tests positionals'";
-    let opt3_vals = ["fast", "slow"];
-    let pos3_vals = ["vi", "emacs"];
-
-    b.iter(|| App::new("claptests")
-                    // Test version from Cargo.toml
-                    .version("0.1")
-                    .about("tests clap library")
-                    .author("Kevin K. <kbknapp@gmail.com>")
-                    .args_from_usage(args)
-                    .arg(Arg::from_usage("-f --flag... 'tests flags'")
-                                 .global(true))
-                    .args(vec![
-                              Arg::from_usage("[flag2] -F 'tests flags with exclusions'").conflicts_with("flag").requires("option2"),
-                              Arg::from_usage("--long-option-2 [option2] 'tests long options with exclusions'").conflicts_with("option").requires("positional2"),
-                              Arg::from_usage("[positional2] 'tests positionals with exclusions'"),
-                              Arg::from_usage("-O --Option [option3] 'tests options with specific value sets'").possible_values(&opt3_vals),
-                              Arg::from_usage("[positional3]... 'tests positionals with specific values'").possible_values(&pos3_vals),
-                              Arg::from_usage("--multvals [multvals] 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
-                              Arg::from_usage("--multvalsmo [multvalsmo]... 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
-                              Arg::from_usage("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
-                              Arg::from_usage("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3)
-                        ])
-                    .subcommand(SubCommand::with_name("subcmd")
-                                            .about("tests subcommands")
-                                            .version("0.1")
-                                            .author("Kevin K. <kbknapp@gmail.com>")
-                                            .arg_from_usage("-o --option [scoption]... 'tests options'")
-                                            .arg_from_usage("[scpositional] 'tests positionals'"))
-                    .get_matches_from(vec![""]));
+    b.iter(|| create_app!().get_matches_from(vec![""]));
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -53,3 +53,53 @@ fn parse_clean(b: &mut Bencher) {
     b.iter(|| create_app!().get_matches_from(vec![""]));
 }
 
+#[bench]
+fn parse_flag(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "-f"]));
+}
+
+#[bench]
+fn parse_option(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "-o", "option1"]));
+}
+
+#[bench]
+fn parse_positional(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "arg1"]));
+}
+
+#[bench]
+fn parse_sc_clean(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "subcmd"]));
+}
+
+#[bench]
+fn parse_sc_flag(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "subcmd", "-f"]));
+}
+
+#[bench]
+fn parse_sc_option(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "subcmd", "-o", "option1"]));
+}
+
+#[bench]
+fn parse_sc_positional(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "subcmd", "arg1"]));
+}
+
+#[bench]
+fn parse_complex1(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "-ff", "-o", "option1", "arg1", "-O", "fast", "arg2", "--multvals", "one", "two", "three"]));
+}
+
+#[bench]
+fn parse_complex2(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "arg1", "-f", "arg2", "--long-option-2", "some", "-O", "slow", "--multvalsmo", "one", "two", "--minvals2", "3", "2", "1"]));
+}
+
+
+#[bench]
+fn parse_sc_complex(b: &mut Bencher) {
+    b.iter(|| create_app!().get_matches_from(vec!["", "subcmd", "-f", "-o", "option1", "arg1"]));
+}

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,81 @@
+#![feature(test)]
+
+extern crate clap;
+extern crate test;
+
+use clap::{App, Arg, SubCommand};
+
+use test::Bencher;
+
+#[bench]
+fn build(b: &mut Bencher) {
+    let m_val_names = ["one", "two"];
+    let args = "-o --option=[opt]... 'tests options'
+                            [positional] 'tests positionals'";
+    let opt3_vals = ["fast", "slow"];
+    let pos3_vals = ["vi", "emacs"];
+
+    b.iter(|| App::new("claptests")
+                    // Test version from Cargo.toml
+                    .version("0.1")
+                    .about("tests clap library")
+                    .author("Kevin K. <kbknapp@gmail.com>")
+                    .args_from_usage(args)
+                    .arg(Arg::from_usage("-f --flag... 'tests flags'")
+                                 .global(true))
+                    .args(vec![
+                              Arg::from_usage("[flag2] -F 'tests flags with exclusions'").conflicts_with("flag").requires("option2"),
+                              Arg::from_usage("--long-option-2 [option2] 'tests long options with exclusions'").conflicts_with("option").requires("positional2"),
+                              Arg::from_usage("[positional2] 'tests positionals with exclusions'"),
+                              Arg::from_usage("-O --Option [option3] 'tests options with specific value sets'").possible_values(&opt3_vals),
+                              Arg::from_usage("[positional3]... 'tests positionals with specific values'").possible_values(&pos3_vals),
+                              Arg::from_usage("--multvals [multvals] 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
+                              Arg::from_usage("--multvalsmo [multvalsmo]... 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
+                              Arg::from_usage("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
+                              Arg::from_usage("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3)
+                        ])
+                    .subcommand(SubCommand::with_name("subcmd")
+                                            .about("tests subcommands")
+                                            .version("0.1")
+                                            .author("Kevin K. <kbknapp@gmail.com>")
+                                            .arg_from_usage("-o --option [scoption]... 'tests options'")
+                                            .arg_from_usage("[scpositional] 'tests positionals'")));
+}
+
+
+#[bench]
+fn parse_clean(b: &mut Bencher) {
+    let m_val_names = ["one", "two"];
+    let args = "-o --option=[opt]... 'tests options'
+                            [positional] 'tests positionals'";
+    let opt3_vals = ["fast", "slow"];
+    let pos3_vals = ["vi", "emacs"];
+
+    b.iter(|| App::new("claptests")
+                    // Test version from Cargo.toml
+                    .version("0.1")
+                    .about("tests clap library")
+                    .author("Kevin K. <kbknapp@gmail.com>")
+                    .args_from_usage(args)
+                    .arg(Arg::from_usage("-f --flag... 'tests flags'")
+                                 .global(true))
+                    .args(vec![
+                              Arg::from_usage("[flag2] -F 'tests flags with exclusions'").conflicts_with("flag").requires("option2"),
+                              Arg::from_usage("--long-option-2 [option2] 'tests long options with exclusions'").conflicts_with("option").requires("positional2"),
+                              Arg::from_usage("[positional2] 'tests positionals with exclusions'"),
+                              Arg::from_usage("-O --Option [option3] 'tests options with specific value sets'").possible_values(&opt3_vals),
+                              Arg::from_usage("[positional3]... 'tests positionals with specific values'").possible_values(&pos3_vals),
+                              Arg::from_usage("--multvals [multvals] 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
+                              Arg::from_usage("--multvalsmo [multvalsmo]... 'Tests mutliple values, not mult occs'").value_names(&m_val_names),
+                              Arg::from_usage("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
+                              Arg::from_usage("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3)
+                        ])
+                    .subcommand(SubCommand::with_name("subcmd")
+                                            .about("tests subcommands")
+                                            .version("0.1")
+                                            .author("Kevin K. <kbknapp@gmail.com>")
+                                            .arg_from_usage("-o --option [scoption]... 'tests options'")
+                                            .arg_from_usage("[scpositional] 'tests positionals'"))
+                    .get_matches_from(vec![""]));
+}
+


### PR DESCRIPTION
See #167.

This PR includes two benchmarks: one for building the `App` and one for clean parse. I am open to changing function names or the filename.

I think the variables (`m_val_names`, `args`, etc.) can be moved to `static`, but I don't know the consequence of doing so.

I didn't think benchmarks are big enough to have their own commit message, so I put it under `tests`.