### PR TITLE
tests(Mixed args): Add failing test for mixed argument types

### DIFF
--- a/tests/app_mixed_args.rs
+++ b/tests/app_mixed_args.rs
@@ -1,0 +1,17 @@
+extern crate clap;
+
+use clap::{App, Arg};
+
+#[test]
+fn mixed_positional_and_options() {
+    App::new("mixed_positional_and_options")
+        .arg(Arg::with_name("feed")
+             .short("f")
+             .long("feed")
+             .takes_value(true)
+             .multiple(true))
+        .arg(Arg::with_name("config")
+             .required(true)
+             .index(1))
+        .get_matches_from(vec!["", "--feed", "1", "config.toml"]);
+}


### PR DESCRIPTION
Not sure if I'm missing anything but this code was extracted from my project because the arguments are not being parsed as expected.

It is expected that the added test will pass by assigning the value
`config.toml` to the `config` argument and `1` to the `feed` argument
but it currently fails with the error:

    error: The following required arguments were not supplied:
      '<config>'

    USAGE:
      mixed_positional_and_options <config> --feed <feed>...

    For more information try --help