### PR TITLE
Added ability for users to handle errors themselves

### DIFF
--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -1,10 +1,182 @@
+use std::error::Error;
+use std::fmt;
+
+/// Command line argument parser error types
+#[derive(PartialEq, Debug)]
 pub enum ClapErrorType {
-    Matches,
-    Opt,
-    None
+    /// Error occurs when some possible values were set, but clap found unexpected value
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug").index(1)
+    /// .possible_value("fast")
+    /// .possible_value("slow")
+    /// # ).get_matches_from_safe(vec!["", "other"]);
+    InvalidValue,
+    /// Error occurs when clap found unexpected flag or option
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::from_usage("-f, --flag 'some flag'")
+    /// # ).get_matches_from_safe(vec!["", "--other"]);
+    InvalidArgument,
+    /// Error occurs when clap found unexpected subcommand
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, SubCommand};
+    /// # let result = App::new("myprog")
+    /// #                    .subcommand(
+    /// SubCommand::with_name("conifg")
+    ///                .about("Used for configuration")
+    ///                .arg(Arg::with_name("config_file")
+    ///                           .help("The configuration file to use")
+    ///                           .index(1))
+    /// # ).get_matches_from_safe(vec!["", "other"]);
+    InvalidSubcommand,
+    /// Error occurs when option does not allow empty values but some was found
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug")
+    /// .empty_values(false))
+    /// #                 .arg(
+    /// # Arg::with_name("color")
+    /// # ).get_matches_from_safe(vec!["", "--debug", "--color"]);
+    EmptyValue,
+    /// Parser inner error
+    OptionError,
+    /// Parser inner error
+    ArgumentError,
+    /// Parser inner error
+    ValueError,
+    /// Error occurs when argument got more values then were expected
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug").index(1)
+    /// .max_values(2)
+    /// # ).get_matches_from_safe(vec!["", "too", "much", "values"]);
+    TooMuchValues,
+    /// Error occurs when argument got less values then were expected
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug").index(1)
+    /// .min_values(3)
+    /// # ).get_matches_from_safe(vec!["", "too", "few"]);
+    TooFewValues,
+    /// Error occurs when clap find two ore more conflicting arguments
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug")
+    /// .conflicts_with("color")
+    /// # ).get_matches_from_safe(vec!["", "--debug", "--color"]);
+    ArgumentConflict,
+    /// Error occurs when one or more required arguments missing
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug")
+    /// .required(true)
+    /// # ).get_matches_from_safe(vec![""]);
+    MissingRequiredArgument,
+    /// Error occurs when required subcommand missing
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg, AppSettings, SubCommand};
+    /// # let result = App::new("myprog")
+    /// #                    .setting(AppSettings::SubcommandRequired)
+    /// #                    .subcommand(
+    /// SubCommand::with_name("conifg")
+    ///                .about("Used for configuration")
+    ///                .arg(Arg::with_name("config_file")
+    ///                           .help("The configuration file to use")
+    ///                           .index(1))
+    /// # ).get_matches_from_safe(vec![""]);
+    MissingSubcommand,
+    /// Error occurs when clap find argument while is was not expecting any
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App};
+    /// # let result = App::new("myprog").get_matches_from_safe(vec!["", "--arg"]);
+    UnexpectedArgument,
+    /// Error occurs when argument was used multiple times and was not set as multiple.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # let result = App::new("myprog")
+    /// #                 .arg(
+    /// # Arg::with_name("debug")
+    /// .multiple(false)
+    /// # ).get_matches_from_safe(vec!["", "--debug", "--debug"]);
+    UnexpectedMultipleUsage
 }
 
+/// Command line argument parser error
+#[derive(Debug)]
 pub struct ClapError {
-	pub error: String,
-	pub error_type: ClapErrorType,
+    /// Formated error message
+    pub error: String,
+    /// Command line argument parser error type
+    pub error_type: ClapErrorType
+}
+
+impl Error for ClapError {
+    fn description(&self) -> &str {
+        &*self.error
+    }
+}
+
+impl fmt::Display for ClapError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.error)
+    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,3 +5,4 @@ mod errors;
 
 pub use self::settings::AppSettings;
 pub use self::app::App;
+pub use self::errors::{ClapError, ClapErrorType};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ extern crate yaml_rust;
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;
 pub use args::{Arg, SubCommand, ArgMatches, ArgGroup};
-pub use app::{App, AppSettings};
+pub use app::{App, AppSettings, ClapError, ClapErrorType};
 pub use fmt::Format;
 
 #[macro_use]


### PR DESCRIPTION
Now you can use `get_matches_safe` instead of `get_matches` if you want to handle errors yourself.

This will allow now to write false-negative tests and check what type of error occurs, see #166 