### PR TITLE
fix: Macro benchmarks

### DIFF
--- a/benches/03_complex.rs
+++ b/benches/03_complex.rs
@@ -135,34 +135,40 @@ fn create_app_builder(b: &mut Bencher) {
     });
 }
 
-// #[bench]
-// fn create_app_macros(b: &mut Bencher) {
-//     b.iter(|| {
-//         clap_app!(claptests => 
-//                 (version: "0.1")
-//                 (about: "tests clap library")
-//                 (author: "Kevin K. <kbknapp@gmail.com>")
-//                 (@arg opt: -o --option +takes_value ... "tests options")
-//                 (@arg positional: [positional] "tests positionals")
-//                 (@arg flag: -f --flag ... +global "tests flags")
-//                 (@arg flag2: -F conflicts_with[flag] requires[option2] "tests flags with exclusions")
-//                 (@arg option2: --long-option-2 conflicts_with[option] requires[positional2] "tests long options with exclusions")
-//                 (@arg positional2: [positional2] "tests positionals with exclusions")
-//                 (@arg option3: -O --Option +takes_value possible_values[fast, slow] "tests options with specific value sets")
-//                 (@arg positional3: [positional3] ... possible_values[vi, emacs] "tests positionals with specific values")
-//                 (@arg multvals: --multvals +takes_value value_names[one, two] "Tests mutliple values, not mult occs")
-//                 (@arg multvalsmo: --multvalsmo ... +takes_value value_names[one, two] "Tests mutliple values, not mult occs")
-//                 (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
-//                 (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
-//                 (@subcommand subcmd => 
-//                     (about: "tests subcommands")
-//                     (version: "0.1")
-//                     (author: "Kevin K. <kbknapp@gmail.com>")
-//                     (@arg scoption: -o --option ... +takes_value "tests options")
-//                     (@arg scpositional: [scpositional] "tests positionals"))
-//         );
-//     });
-// }
+#[bench]
+fn create_app_macros(b: &mut Bencher) {
+    b.iter(|| {
+        clap_app!(claptests =>
+                (version: "0.1")
+                (about: "tests clap library")
+                (author: "Kevin K. <kbknapp@gmail.com>")
+                (@arg opt: -o --option +takes_value ... "tests options")
+                (@arg positional: index(1) "tests positionals")
+                (@arg flag: -f --flag ... +global "tests flags")
+                (@arg flag2: -F conflicts_with[flag] requires[option2]
+                    "tests flags with exclusions")
+                (@arg option2: --long_option_2 conflicts_with[option] requires[positional2]
+                    "tests long options with exclusions")
+                (@arg positional2: index(2) "tests positionals with exclusions")
+                (@arg option3: -O --Option +takes_value possible_value[fast slow]
+                    "tests options with specific value sets")
+                (@arg positional3: index(3) ... possible_value[vi emacs]
+                    "tests positionals with specific values")
+                (@arg multvals: --multvals +takes_value value_name[one two]
+                    "Tests mutliple values, not mult occs")
+                (@arg multvalsmo: --multvalsmo ... +takes_value value_name[one two]
+                    "Tests mutliple values, not mult occs")
+                (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
+                (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
+                (@subcommand subcmd =>
+                    (about: "tests subcommands")
+                    (version: "0.1")
+                    (author: "Kevin K. <kbknapp@gmail.com>")
+                    (@arg scoption: -o --option ... +takes_value "tests options")
+                    (@arg scpositional: index(1) "tests positionals"))
+        );
+    });
+}
 
 #[bench]
 fn parse_clean(b: &mut Bencher) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -813,7 +813,7 @@ macro_rules! clap_app {
         clap_app!{ @arg ($arg.value_name(stringify!($var))) (+) $($tail)* }
     };
     (@arg ($arg:expr) (-) [$var:ident] $($tail:tt)*) => {
-        clap_app!{ @arg ($arg.value_name(stringify!($var))) +takes_value (+) $($tail)* }
+        clap_app!{ @arg ($arg.value_name(stringify!($var))) (+) +takes_value $($tail)* }
     };
     (@arg ($arg:expr) (+) [$var:ident] $($tail:tt)*) => {
         clap_app!{ @arg ($arg.value_name(stringify!($var))) (+) $($tail)* }


### PR DESCRIPTION
- `(+)` in wrong location in macro definition (Sorry).
- `value_name(s)` and `possible_value(s)`, macro implementation repeats over non plural functions
- `--long-option-2` -> `--long_option_2` Is this a problem? If so - feel free to use the manual function via `long("long-option-2")`
- `[positional]` expands to `value_name("positional") takes_value(true)` not `index(1)`