### PR TITLE
Replace crate_version!() macro with simpler call

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -732,11 +732,7 @@ macro_rules! arg_enum {
 #[macro_export]
 macro_rules! crate_version {
     () => {
-        format!("{}.{}.{}{}",
-            env!("CARGO_PKG_VERSION_MAJOR"),
-            env!("CARGO_PKG_VERSION_MINOR"),
-            env!("CARGO_PKG_VERSION_PATCH"),
-            option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""))
+        env!("CARGO_PKG_VERSION").to_owned()
     }
 }
 


### PR DESCRIPTION
As of https://github.com/rust-lang/cargo/pull/1094, cargo publishes the full crate version as `CARGO_PKG_VERSION`, rather than *just* the parts of it.

This replaces the more complicated call with simply `env!("CARGO_PKG_VERSION").to_owned()`. The `.to_owned()` is there as well to ensure backwards compatibility is retained, as the old version of the macro produced a String not `&str`.

This new version of the macro is more succinct, and has slightly less overhead. This does not break compatibility with any stable rust versions, as the change to cargo was made before the 1.0.0 release.