### PR TITLE
fix: flush the buffer in App::print_version()

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1845,10 +1845,12 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                -> io::Result<()> {
         // Print the binary name if existing, but replace all spaces with hyphens in case we're
         // dealing with subcommands i.e. git mv is translated to git-mv
-        writeln!(w, "{} {}", &self.bin_name.clone().unwrap_or(
+        try!(writeln!(w, "{} {}", &self.bin_name.clone().unwrap_or(
             self.name.clone())[..].replace(" ", "-"),
             self.version.unwrap_or("")
-        )
+        ));
+
+        w.flush()
     }
 
     // Reports and error to stderr along with an optional usage statement and optionally quits


### PR DESCRIPTION
In the functions
- `App::check_for_help_and_version`
- `App::parse_long_arg`

the `BufWriter` created for `stdout` should be explicitly flushed before calling `std::process::exit`, otherwise it will never get flushed (the destructor is not called because `exit` never returns). 
To fix this, `App::print_version`, the function actually handling the write should flush the received buffer.

Without this patch, the following example prints nothing to `stdout` when called with the `-V` argument:
```rust
extern crate clap;
use clap::App;

fn main() {
    let _args = App::new("app")
                    .version("9001")
                    .get_matches();
    println!("done");
}
```