### PR TITLE
fix(ArgGroup) added asserts to help users to configure clap properly

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1330,6 +1330,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                 }
             }
         }
+        assert!(args.len() > 0, "ArgGroup '{}' doesn't contain any args", group);
         args.dedup();
         args.iter().map(ToOwned::to_owned).collect()
     }
@@ -1362,6 +1363,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                 }
             }
         }
+        assert!(args.len() > 0, "ArgGroup '{}' doesn't contain any args", group);
         args.dedup();
         args.iter().map(|s| *s).collect()
     }

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -143,6 +143,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     pub fn add(mut self,
                n: &'ar str)
                -> Self {
+        assert!(self.name != n, "ArgGroup '{}' can not have same name as arg inside it", self.name);
         self.args.push(n);
         self
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use super::{App, Arg, SubCommand};
+use super::{App, Arg, ArgGroup, SubCommand};
 use std::vec::Vec;
 
 arg_enum!{
@@ -908,4 +908,36 @@ fn create_multiple_subcommands() {
                                         .arg(Arg::with_name("roster").short("r"))])
                 .arg(Arg::with_name("other").long("other"))
                 .get_matches();
+}
+
+#[test]
+#[should_panic]
+fn empty_group() {
+    let _ = App::new("empty_group")
+        .arg(Arg::from_usage("-f, --flag 'some flag'"))
+        .arg_group(ArgGroup::with_name("vers")
+            .required(true))
+        .get_matches();
+}
+
+#[test]
+#[should_panic]
+fn empty_group_2() {
+    let _ = App::new("empty_group")
+        .arg(Arg::from_usage("-f, --flag 'some flag'"))
+        .arg_group(ArgGroup::with_name("vers")
+            .required(true)
+            .add_all(&["ver", "major"]))
+        .get_matches();
+}
+
+#[test]
+#[should_panic]
+fn errous_group() {
+    let _ = App::new("errous_group")
+        .arg(Arg::from_usage("-f, --flag 'some flag'"))
+        .arg_group(ArgGroup::with_name("vers")
+            .add("vers")
+            .required(true))
+        .get_matches();
 }


### PR DESCRIPTION
Also I've added tests for this change

Now you will get 
```
ArgGroup %Your_ArgGroup_Name% doesn't contain any args
```
instead of
```
thread '<main>' panicked at 'arithmetic operation overflowed'
```
And 
```
ArgGroup %Your_ArgGroup_Name% can not have same name as arg inside it
```
instead of 
```
thread '<main>' has overflowed its stack
```