### PR TITLE
Issue 262 - Result and Lossy options for invalid Unicode

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -34,7 +34,7 @@ const INTERNAL_ERROR_MSG: &'static str = "Fatal internal error. Please consider 
 /// order (so long as `.get_matches()` is the last method called).
 ///
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # use clap::{App, Arg};
@@ -108,7 +108,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// information. The name should not contain spaces (hyphens '-' are ok).
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -167,7 +167,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// YAML file (relative to the current file, like modules work). That YAML object can then be
     /// passed to this function.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```ignore
     /// # use clap::App;
@@ -247,7 +247,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// Sets a string of author(s) and will be displayed to the user when they request the help
     /// information with `--help` or `-h`.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -268,7 +268,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** This command **should not** be used for SubCommands.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -286,7 +286,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// Sets a string briefly describing what the program does and will be displayed when
     /// displaying help information.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -306,7 +306,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// information. This additional help is often used to describe how to use the arguments,
     /// or caveats to be noted.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::App;
@@ -330,7 +330,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** This defaults to false (using subcommand does *not* negate requirements)
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::App;
@@ -352,7 +352,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** This defaults to false (subcommands do *not* need to be present)
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::App;
@@ -370,7 +370,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// Sets a string of the version number to be displayed when displaying version or help
     /// information.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -398,7 +398,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// showing the usage.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -425,7 +425,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// specify a `.help()` for them as well.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -462,7 +462,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// non `-` chacter will be used as the `short` version
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -487,7 +487,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// non `-` chacter will be used as the `short` version
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -512,7 +512,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** Subcommands count as arguments
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -531,7 +531,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** This does **not** hide the subcommand from usage strings on error
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, SubCommand};
@@ -556,7 +556,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// **NOTE:** The version for the current command and this setting must be set **prior** to
     /// adding any subcommands
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -585,7 +585,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** Do not set this value to false, it will have undesired results!
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -612,7 +612,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     ///
     /// **NOTE:** This setting is cosmetic only and does not affect any functionality.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -643,7 +643,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// behavior for all subcommands, you must set this on each command (needing this is extremely
     /// rare)
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -671,7 +671,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// still be displayed and exit. If this is *not* the desired result, consider using
     /// `.arg_required_else_help()`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -688,7 +688,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
 
     /// Enables Application level settings, passed as argument
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, AppSettings};
@@ -721,7 +721,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
 
     /// Enables multiple Application level settings, passed as argument
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, AppSettings};
@@ -748,7 +748,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// one at a time. Using `Arg::from_usage` helps with the verbosity, and still allows full
     /// control over the advanced configuration options.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1068,7 +1068,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// Adds multiple arguments to the list of valid possibilties by iterating over a Vec of Args
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1096,7 +1096,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// `Arg` other than what `Arg::from_usage()` supports.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1120,7 +1120,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// options.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1160,7 +1160,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// group
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -1224,7 +1224,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// group
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -1252,7 +1252,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// usage.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -1282,7 +1282,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// Adds multiple subcommands to the list of valid possibilties by iterating over a Vec of
     /// `SubCommand`s
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -1575,7 +1575,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
 
     /// Prints the full help message to `io::stdout()` using a `BufWriter`
     ///
-    /// # Examples
+    /// # Exampless
     /// ```no_run
     /// # use clap::App;
     /// # use std::io;
@@ -1886,7 +1886,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// If any arguments contain invalid unicode characters. If this is not desired it is
     /// recommended to use the `*_safe()` or `*_lossy()` versions of this method.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1903,7 +1903,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// the real parsing function for all subcommands. Invalid unicode characters are replaced with
     /// `U+FFFD REPLACEMENT CHARACTER`
     ///
-    /// # Examples
+    /// # Exampless
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1923,7 +1923,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// manually.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1945,7 +1945,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// manually.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1969,7 +1969,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// `App::get_matches()`
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -2010,7 +2010,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// `App::get_matches()`
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -2056,7 +2056,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// `ClapErrorType::InvalidUnicode`
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -2089,7 +2089,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// manually.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -2163,7 +2163,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// **NOTE:** Invalid unicode characters will result in an `Err` with type 
     /// `ClapErrorType::InvalidUnicode`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -2198,7 +2198,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
     /// **NOTE:** Invalid unicode characters will result in an `Err` with type 
     /// `ClapErrorType::InvalidUnicode`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -178,6 +178,24 @@ pub enum ClapErrorType {
     ///     .get_matches_from_safe(vec!["", "--debug", "--debug"]);
     /// ```
     UnexpectedMultipleUsage,
+    /// Error occurs when argument contains invalid unicode characters
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// # use std::os::unix::ffi::OsStringExt;
+    /// # use std::ffi::OsString;
+    /// let result = App::new("myprog")
+    ///     .arg(Arg::with_name("debug")
+    ///         .short("u")
+    ///         .takes_value(true))
+    ///     .get_matches_from_safe(vec![OsString::from_vec(vec![0x20]), 
+    ///                                 OsString::from_vec(vec![0xE9])]);
+    /// assert!(result.is_err());
+    /// ```
+    InvalidUnicode
 }
 
 /// Command line argument parser error

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -8,7 +8,7 @@ pub enum ClapErrorType {
     /// Error occurs when some possible values were set, but clap found unexpected value
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -22,7 +22,7 @@ pub enum ClapErrorType {
     /// Error occurs when clap found unexpected flag or option
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -34,7 +34,7 @@ pub enum ClapErrorType {
     /// Error occurs when clap found unexpected subcommand
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -50,7 +50,7 @@ pub enum ClapErrorType {
     /// Error occurs when option does not allow empty values but some was found
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -70,7 +70,7 @@ pub enum ClapErrorType {
     /// Error occurs when argument got more values then were expected
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -83,7 +83,7 @@ pub enum ClapErrorType {
     /// Error occurs when argument got less values then were expected
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -96,7 +96,7 @@ pub enum ClapErrorType {
     /// Error occurs when clap find two ore more conflicting arguments
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -109,7 +109,7 @@ pub enum ClapErrorType {
     /// Error occurs when one or more required arguments missing
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -122,7 +122,7 @@ pub enum ClapErrorType {
     /// Error occurs when required subcommand missing
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, AppSettings, SubCommand};
@@ -140,7 +140,7 @@ pub enum ClapErrorType {
     /// `AppSettings::ArgRequiredElseHelp` was used
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, AppSettings, SubCommand};
@@ -157,7 +157,7 @@ pub enum ClapErrorType {
     /// Error occurs when clap find argument while is was not expecting any
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App};
@@ -168,7 +168,7 @@ pub enum ClapErrorType {
     /// Error occurs when argument was used multiple times and was not set as multiple.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -181,7 +181,7 @@ pub enum ClapErrorType {
     /// Error occurs when argument contains invalid unicode characters
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -10,7 +10,7 @@ pub enum AppSettings {
     ///
     /// **NOTE:** This defaults to false (using subcommand does *not* negate requirements)
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, AppSettings};
@@ -23,7 +23,7 @@ pub enum AppSettings {
     ///
     /// **NOTE:** This defaults to false (subcommands do *not* need to be present)
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, AppSettings};
@@ -37,7 +37,7 @@ pub enum AppSettings {
     ///
     /// **NOTE:** Subcommands count as arguments
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, AppSettings};
@@ -52,7 +52,7 @@ pub enum AppSettings {
     /// **NOTE:** The version for the current command and this setting must be set **prior** to
     /// adding any subcommands
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand, AppSettings};
@@ -72,7 +72,7 @@ pub enum AppSettings {
     ///
     /// **NOTE:** Do not set this value to false, it will have undesired results!
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand, AppSettings};
@@ -90,7 +90,7 @@ pub enum AppSettings {
     ///
     /// **NOTE:** This setting is cosmetic only and does not affect any functionality.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand, AppSettings};
@@ -112,7 +112,7 @@ pub enum AppSettings {
     /// behavior for all subcommands, you must set this on each command (needing this is extremely
     /// rare)
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, AppSettings};
@@ -131,7 +131,7 @@ pub enum AppSettings {
     /// still be displayed and exit. If this is *not* the desired result, consider using
     /// `.arg_required_else_help()`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, AppSettings};

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -23,7 +23,7 @@ use usageparser::{UsageParser, UsageToken};
 /// **NOTE*: Fields of this struct are **not** meant to be used directly unless absolutely
 /// required. 99.9% of the tasks can be performed without accessing these fields directly.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # use clap::{App, Arg};
@@ -107,7 +107,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// be displayed when the user prints the usage/help information of the program.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -144,7 +144,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
 
     /// Creates a new instace of `Arg` from a .yml (YAML) file.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```ignore
     /// # use clap::Arg;
@@ -252,7 +252,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     ///    as the value names (i.e. `--opt <file> <mode>`). In this case, if no name was specified
     ///    prior to the value names, the long is used as the name by which to access the argument.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -404,7 +404,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// non `-` chacter will be used as the `short` version
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -430,7 +430,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// **NOTE:** Any leading `-` characters will be stripped
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -450,7 +450,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// when they print the usage/help information.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -500,7 +500,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// arguments, they do not need to be set for each.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -526,7 +526,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// arguments, they do not need to be set for each.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -551,7 +551,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// Sets a mutually overridable argument by name. I.e. this argument and
     /// the following argument will override each other in POSIX style
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -572,7 +572,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// Sets a mutually overridable arguments by name. I.e. this argument and
     /// the following argument will override each other in POSIX style
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -600,7 +600,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// **NOTE:** Mutually exclusive and override rules take precedence over being required
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -625,7 +625,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// by default.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -653,7 +653,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// will be used when printing the help/usage information to the user.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -677,7 +677,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// to the user.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -702,7 +702,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// are ignored as flags cannot have a values or an `index`.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -729,7 +729,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// parent command, but the user supplied the arguments `top cmd1 cmd2 --flag` *only* `cmd2`'s
     /// `ArgMatches` would return `true` if tested for `.is_present("flag")`.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -751,7 +751,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// **NOTE:** Defaults to `true` (Explicit empty values are allowed)
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -771,7 +771,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     ///
     /// **NOTE:** This does **not** hide the argument from usage strings on error
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -793,7 +793,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// **NOTE:** This setting only applies to options and positional arguments
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -823,7 +823,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// **NOTE:** This setting only applies to options and positional arguments
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -847,7 +847,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// Specifies the name of the group the argument belongs to.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -872,7 +872,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// allow `-f <file> <file> <file> -f <file> <file> <file>` where as *not* setting
     /// `.multiple(true)` would only allow one occurrence of this argument.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -899,7 +899,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// with `Rc` pointers. And the value to be checked will be allocated an extra time in order to
     /// to be passed to the closure.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -932,7 +932,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     ///
     /// **NOTE:** This implicity sets `.multiple(true)`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -966,7 +966,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// **NOTE:** `qty` *must* be > 0. If you wish to have an argument with 0 or more values prefer
     /// two separate arguments (a flag, and an option with multiple values).
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1000,7 +1000,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// allow `-f <file> <file> <file> -f <file> <file> <file>` where as *not* setting
     /// `.multiple(true)` would only allow one occurrence of this argument.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -1028,7 +1028,7 @@ impl<'n, 'l, 'h, 'g, 'p, 'r> Arg<'n, 'l, 'h, 'g, 'p, 'r> {
     /// Specifies the name for value of option or positional arguments. This name is cosmetic only,
     /// used for help and usage strings. The name is **not** used to access arguments.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};

--- a/src/args/argmatches.rs
+++ b/src/args/argmatches.rs
@@ -7,7 +7,7 @@ use args::MatchedArg;
 /// the user. To get a new instance of this struct you use `.get_matches()` of the `App` struct.
 ///
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # use clap::{App, Arg};
@@ -65,7 +65,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// Creates a new instance of `ArgMatches`. This ins't called directly, but
     /// through the `.get_matches()` method of `App`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -87,7 +87,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// *NOTE:* If getting a value for an option or positional argument that allows multiples,
     /// prefer `values_of()` as `value_of()` will only return the _*first*_ value.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -116,7 +116,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// that takes multiple values at runtime). If the option wasn't present at runtime it
     /// returns `None`
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -145,7 +145,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// Returns if an argument was present at runtime.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -174,7 +174,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// allow multiple occurrences, but will obviously only return `0` or `1`.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
@@ -199,7 +199,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// present at runtime.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -227,7 +227,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// the name of sub-subcommand's names
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -250,7 +250,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// wasn't found.
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -272,7 +272,7 @@ impl<'n, 'a> ArgMatches<'n, 'a> {
     /// Returns a string slice of the usage statement for the `App` (or `SubCommand`)
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -28,7 +28,7 @@ use yaml_rust::Yaml;
 /// `--minor`, and `--patch`. All of these arguments shouldn't be used at one time but you want to
 /// specify that *at least one* of them is used. For this, you can create a group.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # use clap::{App, ArgGroup};
@@ -58,7 +58,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// Creates a new instace of `ArgGroup` using a unique string name.
     /// The name will only be used by the library consumer and not displayed to the use.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -78,7 +78,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
 
     /// Creates a new instace of `ArgGroup` from a .yml (YAML) file.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```ignore
     /// # use clap::ArgGroup;
@@ -131,7 +131,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// Adds an argument to this group by name
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -151,7 +151,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// Adds multiple arguments to this group by name
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -175,7 +175,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// conflicting with another argument).
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -198,7 +198,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// **NOTE:** The name provided may be an argument, or group name
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -225,7 +225,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// **NOTE:** The names provided may be an argument, or group name
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -250,7 +250,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// **NOTE:** The name provided may be an argument, or group name
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};
@@ -277,7 +277,7 @@ impl<'n, 'ar> ArgGroup<'n, 'ar> {
     /// **NOTE:** The names provided may be an argument, or group name
     ///
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, ArgGroup};

--- a/src/args/subcommand.rs
+++ b/src/args/subcommand.rs
@@ -11,7 +11,7 @@ use ArgMatches;
 /// subcommand for their program. SubCommands are treated like "sub apps" and contain all the same
 /// possibilities (such as their own arguments and subcommands).
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # use clap::{App, Arg, SubCommand};
@@ -34,7 +34,7 @@ impl<'n, 'a> SubCommand<'n, 'a> {
     /// Creates a new instance of a subcommand requiring a name. Will be displayed
     /// to the user when they print version or help and usage information.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg, SubCommand};
@@ -48,7 +48,7 @@ impl<'n, 'a> SubCommand<'n, 'a> {
 
     /// Creates a new instance of a subcommand from a YAML (.yml) document
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```ignore
     /// # use clap::{App, Arg, SubCommand};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -247,7 +247,7 @@ macro_rules! for_match {
 /// standard syntax.
 ///
 ///
-/// # Example single value
+/// # Examples single value
 ///
 /// ```no_run
 /// # #[macro_use]
@@ -268,7 +268,7 @@ macro_rules! for_match {
 /// ```
 ///
 ///
-/// # Example multiple values
+/// # Examples multiple values
 ///
 /// ```no_run
 /// # #[macro_use]
@@ -337,7 +337,7 @@ macro_rules! value_t {
 /// standard syntax.
 ///
 ///
-/// # Example single value
+/// # Examples single value
 ///
 /// ```no_run
 /// # #[macro_use]
@@ -354,7 +354,7 @@ macro_rules! value_t {
 /// ```
 ///
 ///
-/// # Example multiple values
+/// # Examples multiple values
 ///
 /// ```no_run
 /// # #[macro_use]
@@ -437,7 +437,7 @@ macro_rules! value_t_or_exit {
 ///
 /// **NOTE:** This macro automaically implements std::str::FromStr and std::fmt::Display
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # #[macro_use]
@@ -513,7 +513,7 @@ macro_rules! simple_enum {
 /// These enums support pub (or not) and use of the #[derive()] traits
 ///
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # #[macro_use]
@@ -718,7 +718,7 @@ macro_rules! arg_enum {
 
 /// Allows you pull the version for an from your Cargo.toml as MAJOR.MINOR.PATCH_PKGVERSION_PRE
 ///
-/// # Example
+/// # Examples
 /// ```no_run
 /// # #[macro_use]
 /// # extern crate clap;

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -1,0 +1,30 @@
+extern crate clap;
+
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use clap::{App, Arg, ClapErrorType};
+
+#[test]
+fn invalid_unicode_safe() {
+    let m = App::new("bad_unicode")
+        .arg(Arg::from_usage("<arg> 'some arg'"))
+        .get_matches_from_safe(vec![OsString::from_vec(vec![0x20]), 
+                                    OsString::from_vec(vec![0xe9])]);
+    assert!(m.is_err());
+    if let Err(e) = m {
+        assert_eq!(e.error_type, ClapErrorType::InvalidUnicode);
+    }
+}
+
+#[test]
+fn invalid_unicode_lossy() {
+    if let Ok(m) = App::new("bad_unicode")
+        .arg(Arg::from_usage("<arg> 'some arg'"))
+        .get_matches_from_safe_lossy(vec![OsString::from_vec(vec![0x20]), 
+                                          OsString::from_vec(vec![0xe9])]) {
+        assert!(m.is_present("arg"));
+        assert_eq!(m.value_of("arg").unwrap(), "\u{FFFD}");
+    } else {
+        panic!("FAILED")
+    }
+}


### PR DESCRIPTION
This allows not `panic!`ing on invalid unicode characters, and the option of returning lossy results. This does **not** turn all results into an `OsStr` preserving invalid unicode.

If this helps with #262 we can merge (after review), otherwise we'll continue to discuss if there's a better way to handle this issue.