### PR TITLE
fix: Improved --long=val1,val2

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum ClapError<'a> {
     UnexpectedLong(String) ,       // unknown long provided
     UnexpectedShort(char),         // unknown short provided
     UnexpectedPositional(String),  // unknown positional provided
+    UnexpectedValue(String),       // unexpected value provided
 }
 
 impl<'a> fmt::Display for ClapError<'a> {
@@ -26,6 +27,7 @@ impl<'a> Error for ClapError<'a> {
             UnexpectedLong(_) => "unexpected long argument provided",
             UnexpectedShort(_) => "unexpected short argument provided",
             UnexpectedPositional(_) => "unexpected positional provided",
+            UnexpectedValue(_) => "unexpected value provided",
         }
     }
 }

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -68,9 +68,9 @@ fn long_with_equal_sign() {
 fn long_with_equal_sign_multiple() {
     let ref mut sample = vec!["--foo=val1,val2,val3"].into_iter();
     let ac = App::with_rules(vec![
-        Rule::with_name("foo").long("foo").takes_value_unnamed_n_times(3),
+        Rule::with_name("foo").long("foo").takes_value_unnamed().multiple(),
     ]);
     let matches = ac.get_matches(sample).unwrap();
-    assert_eq!(matches.get("foo").unwrap().get_occurrences(), 1);
+    assert_eq!(matches.get("foo").unwrap().get_occurrences(), 3);
     assert_eq!(&*matches.get("foo").unwrap().get_vec(), &["val1", "val2", "val3"]);
 }


### PR DESCRIPTION
- Improved --long=val,val parsing such that each item is treated as
  another occurance

- Return a ClapError when a user attempts to do --flag=val1;
  UnexpectedValue.