### PR TITLE
Avoid suggesting star dependencies.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ The following is a list of contributors to the [clap](https://github.com/kbknapp
  * [grossws](https://github.com/grossws)
  * [Ivan Dmitrievsky](https://github.com/idmit) <<ivan.dmitrievsky@gmail.com>>
  * [Homu](https://github.com/homu)
+ * [Huon Wilson](https://github.com/huonw)
  * [J/A](https://github.com/archer884)
  * [Jacob Helwig](https://github.com/jhelwig) <<jacob@technosorcery.net>>
  * [James McGlashan](https://github.com/james-darkfox)

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ fn main() {
 
 If you were to compile any of the above programs and run them with the flag `--help` or `-h` (or `help` subcommand, since we defined `test` as a subcommand) the following would be output
 
-**NOTE**: The YAML option requires adding a special `features` flag when compiling `clap` because it is not compiled by default since it takes additional dependencies that some people may not need. Simply change your `clap = "*"` to `clap = {version = "*", features = ["yaml"]}` in your `Cargo.toml` to use the YAML version.
+**NOTE**: The YAML option requires adding a special `features` flag when compiling `clap` because it is not compiled by default since it takes additional dependencies that some people may not need. Simply change your `clap = "1"` to `clap = {version = "1", features = ["yaml"]}` in your `Cargo.toml` to use the YAML version.
 
 ```sh
 $ myapp --help
@@ -413,7 +413,7 @@ To test out `clap`'s default auto-generated help/version follow these steps:
 *
 ```toml
 [dependencies]
-clap = "*"
+clap = "1"
 ```
 
 * Add the following to your `src/main.rs`
@@ -436,7 +436,7 @@ For full usage, add `clap` as a dependency in your `Cargo.toml` file to use from
 
  ```toml
  [dependencies]
- clap = "*"
+ clap = "1"
  ```
  Or track the latest on the master branch at github:
 
@@ -457,7 +457,7 @@ If you'd like to keep your dependency list to **only** `clap`, you can disable a
 
 ```toml
 [dependencies.clap]
-version = "*"
+version = "1"
 default-features = false
 ```
 
@@ -465,7 +465,7 @@ You can also selectively enable only the features you'd like to include, by addi
 
 ```toml
 [dependencies.clap]
-version = "*"
+version = "1"
 default-features = false
 
 # Cherry-pick the features you'd like to use


### PR DESCRIPTION
A `*` version constraint makes it hard/impossible to release a breaking
change (e.g. clap 2.0) without causing people's code to break.  `cargo
update` with a `*` dependency will happily move from (say) 1.4 to 2.0,
even though semver says these may be a breaking change. Using a more
precise dependency constraint gives the crate author more flexibility in
making breaking changes, and makes users of the crate happier if/when
they do happen.

https://github.com/rust-lang/rfcs/pull/1241 contains a bit more
discussion about this.