### PR TITLE
fix(Errors): tones down quoting in some error messages

### DIFF
--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -81,8 +81,8 @@ USAGE:
 For more information try --help'''
 
 _required = '''error: The following required arguments were not supplied:
-\t'[positional2]'
-\t'--long-option-2 <option2>'
+\t[positional2]
+\t--long-option-2 <option2>
 
 USAGE:
 \tclaptests [positional2] -F --long-option-2 <option2>

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1645,7 +1645,7 @@ impl<'a, 'v, 'ab, 'u, 'h, 'ar> App<'a, 'v, 'ab, 'u, 'h, 'ar>{
                                                             .collect(),
                                                             Some(matches))
                             .iter()
-                            .fold(String::new(), |acc, s| acc + &format!("\n\t'{}'",
+                            .fold(String::new(), |acc, s| acc + &format!("\n\t{}",
                                 Format::Error(s))[..]))
             },
             ClapErrorType::MissingSubcommand => {


### PR DESCRIPTION
Closes #309 

Turns out it's just a single message which quotes outside a sentence.