### PR TITLE
moving to travis crates infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+sudo: false
 language: rust
-sudo: required
 rust:
   - nightly
   - beta
@@ -17,7 +17,7 @@ script:
 after_success:
   - |
     travis-cargo --only stable doc-upload &&
-    travis-cargo --only stable coveralls -- --features yaml
+    travis-cargo --only stable coveralls --no-sudo -- --features yaml
 env:
   global:
     secure: JLBlgHY6OEmhJ8woewNJHmuBokTNUv7/WvLkJGV8xk0t6bXBwSU0jNloXwlH7FiQTc4TccX0PumPDD4MrMgxIAVFPmmmlQOCmdpYP4tqZJ8xo189E5zk8lKF5OyaVYCs5SMmFC3cxCsKjfwGIexNu3ck5Uhwe9jI0tqgkgM3URA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ script:
     cargo test --features yaml &&
     make -C clap-tests test &&
     travis-cargo --only stable doc -- --features yaml
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev
+    - libelf-dev
+    - libdw-dev
 after_success:
   - |
     travis-cargo --only stable doc-upload &&


### PR DESCRIPTION
The idea is to get rid of `sudo` in the script, so `travis` can run builds on new crates infrastructure. It will increase build speed and decrease load on `travis`.