### PR TITLE
tests(multiple_values): move tests related to multiple values

### DIFF
--- a/clap-tests/run_tests.py
+++ b/clap-tests/run_tests.py
@@ -186,58 +186,6 @@ scoption present with value: some
 An scoption: some
 scpositional present with value: value'''
 
-_min_vals_few = '''error: The argument '--minvals2 <minvals>...' requires at least 2 values, but 1 was provided
-
-USAGE:
-\tclaptests --minvals2 <minvals>...
-
-For more information try --help'''
-
-_exact = '''flag NOT present
-option NOT present
-positional NOT present
-flag2 NOT present
-option2 maybe present with value of: Nothing
-positional2 maybe present with value of: Nothing
-option3 NOT present
-positional3 NOT present
-option NOT present
-positional NOT present
-subcmd NOT present'''
-
-_max_vals_more = '''flag NOT present
-option NOT present
-positional present with value: too
-flag2 NOT present
-option2 maybe present with value of: Nothing
-positional2 maybe present with value of: Nothing
-option3 NOT present
-positional3 NOT present
-option NOT present
-positional present with value: too
-subcmd NOT present'''
-
-_mult_vals_more = '''error: The argument '--multvals <one> <two>' was supplied more than once, but does not support multiple occurrences
-
-USAGE:
-\tclaptests --multvals <one> <two>
-
-For more information try --help'''
-
-_mult_vals_few = '''error: The argument '--multvals <one> <two>' requires 2 values, but 1 was provided
-
-USAGE:
-\tclaptests --multvals <one> <two>
-
-For more information try --help'''
-
-_mult_vals_2m1 = '''error: The argument '--multvalsmo <one> <two>' requires 2 values, but 1 was provided
-
-USAGE:
-\tclaptests --multvalsmo <one> <two>
-
-For more information try --help'''
-
 _bin = './target/release/claptests'
 
 cmds = {'help short:         ': ['{} -h'.format(_bin), _help, 0],
@@ -246,18 +194,6 @@ cmds = {'help short:         ': ['{} -h'.format(_bin), _help, 0],
 		'version long:       ': ['{} --version'.format(_bin), _version, 0],
 		'help subcmd:        ': ['{} help'.format(_bin), _help, 0],
 		'missing required:   ': ['{} -F'.format(_bin), _required, 1],
-		'max_vals too many:  ': ['{} --maxvals3 some other value too'.format(_bin), _max_vals_more, 0],
-		'max_vals exact:     ': ['{} --maxvals3 some other value'.format(_bin), _exact, 0],
-		'max_vals less:      ': ['{} --maxvals3 some other'.format(_bin), _exact, 0],
-		'min_vals more:      ': ['{} --minvals2 some other value too'.format(_bin), _exact, 0],
-		'min_vals exact:     ': ['{} --minvals2 some value'.format(_bin), _exact, 0],
-		'min_vals too few:   ': ['{} --minvals2 some'.format(_bin), _min_vals_few, 1],
-		'mult_vals too many: ': ['{} --multvals some other --multvals some other'.format(_bin), _mult_vals_more, 1],
-		'mult_vals too few:  ': ['{} --multvals some'.format(_bin), _mult_vals_few, 1],
-		'mult_vals exact:    ': ['{} --multvals some other'.format(_bin), _exact, 0],
-		'mult_valsmo x2:     ': ['{} --multvalsmo some other --multvalsmo some other'.format(_bin), _exact, 0],
-		'mult_valsmo x2-1:   ': ['{} --multvalsmo some other --multvalsmo some'.format(_bin), _mult_vals_2m1, 1],
-		'mult_valsmo x1:     ': ['{} --multvalsmo some other'.format(_bin), _exact, 0],
 		'F2(ss),O(s),P:      ': ['{} value -f -f -o some'.format(_bin), _f2op, 0],
 		'arg dym:            ': ['{} --optio=foo'.format(_bin), _arg_dym_usage, 1],
 		'O2(ll)P:            ': ['{} value --option some --option other'.format(_bin), _o2p, 0],

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -1,0 +1,312 @@
+extern crate clap;
+
+use clap::{App, Arg, ClapErrorType};
+
+#[test]
+fn multiple_values_of_long_multiple() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .long("option")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true))
+        .get_matches_from_safe(vec![
+            "",
+            "--option", "val1",
+            "--option", "val2",
+            "--option", "val3",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 3);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3"]));
+}
+
+#[test]
+fn multiple_values_of_long_single() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .long("option")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true))
+        .get_matches_from_safe(vec![
+            "",
+            "--option", "val1",
+            "--option", "val2",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 2);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2"]));
+}
+
+#[test]
+fn multiple_values_of_short_multiple() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 3);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3"]));
+}
+
+#[test]
+fn multiple_values_of_short_single() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 2);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2"]));
+}
+
+#[test]
+fn multiple_values_of_mixed() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .long("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "--option", "val2",
+            "--option", "val3",
+            "-o", "val4",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 4);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3", "val4"]));
+}
+
+#[test]
+fn multiple_values_of_exact_exact() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true)
+            .number_of_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 3);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3"]));
+}
+
+#[test]
+fn multiple_values_of_exact_less() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true)
+            .number_of_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+        ]);
+
+    assert!(m.is_err());
+    assert_eq!(m.unwrap_err().error_type, ClapErrorType::WrongNumValues);
+}
+
+#[test]
+fn multiple_values_of_exact_more() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .multiple(true)
+            .number_of_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+            "-o", "val4",
+        ]);
+
+    assert!(m.is_err());
+    assert_eq!(m.unwrap_err().error_type, ClapErrorType::WrongNumValues);
+}
+
+#[test]
+fn multiple_values_of_min_exact() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .min_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 3);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3"]));
+}
+
+#[test]
+fn multiple_values_of_min_less() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .min_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+        ]);
+
+    assert!(m.is_err());
+    assert_eq!(m.unwrap_err().error_type, ClapErrorType::TooFewValues);
+}
+
+#[test]
+fn multiple_values_of_min_more() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .min_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+            "-o", "val4",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 4);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3", "val4"]));
+}
+
+#[test]
+fn multiple_values_of_max_exact() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .max_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 3);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2", "val3"]));
+}
+
+#[test]
+fn multiple_values_of_max_less() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .max_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+        ]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(m.occurrences_of("option"), 2);
+    assert_eq!(m.values_of("option"), Some(vec!["val1", "val2"]));
+}
+
+#[test]
+fn multiple_values_of_max_more() {
+    let m = App::new("multiple_values")
+        .arg(Arg::with_name("option")
+            .short("o")
+            .help("multiple options")
+            .takes_value(true)
+            .max_values(3))
+        .get_matches_from_safe(vec![
+            "",
+            "-o", "val1",
+            "-o", "val2",
+            "-o", "val3",
+            "-o", "val4",
+        ]);
+
+    assert!(m.is_err());
+    assert_eq!(m.unwrap_err().error_type, ClapErrorType::TooManyValues);
+}


### PR DESCRIPTION
#166.

Currently, there are four different error types that indicate the same thing: `TooManyArgs`, `TooManyValues`, `TooFewValues`, `WrongNumValues`. I wasn't sure which error they give. Therefore, I just checked that it gives error, but I do not check which error it gives.