### PR TITLE
Scopewide attributes

### DIFF
--- a/examples/17_yaml.rs
+++ b/examples/17_yaml.rs
@@ -17,10 +17,10 @@
 #[macro_use]
 extern crate clap;
 
-use clap::App;
-
 #[cfg(feature = "yaml")]
 fn main() {
+    use clap::App;
+
     // To load a yaml file containing our CLI definition such as the example '17_yaml.yml' we can
     // use the convenience macro which loads the file at compile relative to the current file
     // similiar to how modules are found.

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -1,12 +1,12 @@
+#![cfg(not(windows))]
+
 extern crate clap;
 
 use std::ffi::OsString;
-#[cfg(not(windows))]
 use std::os::unix::ffi::OsStringExt;
 use clap::{App, Arg, ClapErrorType};
 
-#[cfg_attr(not(windows), test)]
-#[cfg(not(windows))]
+#[test]
 fn invalid_unicode_safe() {
     let m = App::new("bad_unicode")
         .arg(Arg::from_usage("<arg> 'some arg'"))
@@ -18,8 +18,7 @@ fn invalid_unicode_safe() {
     }
 }
 
-#[cfg_attr(not(windows), test)]
-#[cfg(not(windows))]
+#[test]
 fn invalid_unicode_lossy() {
     if let Ok(m) = App::new("bad_unicode")
         .arg(Arg::from_usage("<arg> 'some arg'"))

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -1,10 +1,11 @@
+#![cfg(feature="yaml")]
+
 #[macro_use]
 extern crate clap;
 
 use clap::App;
 
 #[test]
-#[cfg(feature="yaml")]
 fn create_app_from_yaml() {
     let yml = load_yaml!("app.yml");
     App::from_yaml(yml);


### PR DESCRIPTION
For `tests/yaml.rs`, it makes sense to use scope wide attribute, which applies to the whole file, because yaml test will not be tested without yaml feature.

For `examples/17_yaml.rs`, I moved the `use` statement inside so that seemingly random unused import warning doesn't pop up.

For `tests/unicode.rs`, well, I tried fiddling around with unicode with Windows without much success...