### PR TITLE
chore: bump dependencies bitflags and yaml-rust to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ license = "MIT"
 keywords = ["argument", "command", "arg", "parser", "parse"]
 
 [dependencies]
-bitflags  = "0.3.3"
+bitflags  = "0.4.0"
 vec_map   = "0.4"
 ansi_term = { version = "~0.7", optional = true }
 strsim    = { version = "~0.4.0", optional = true }
-yaml-rust = { version = "~0.2.2", optional = true }
+yaml-rust = { version = "~0.3.0", optional = true }
 clippy    = { version = "~0.0.35", optional = true }
 
 [features]


### PR DESCRIPTION
Bump `bitflags` from 0.3.3 to 0.4.0 and `yaml-rust` from 0.2.2 to 0.3.0.

All tests pass in current stable, beta and nightly (`1.8.0-nightly (38e23e8f7 2016-01-27)`).