### PR TITLE
Allow for more than 256 occurrences of an argument.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,7 @@ The following is a list of contributors to the [clap](https://github.com/kbknapp
  * [Alex Gulyás](https://github.com/alex-gulyas)
  * [Benjamin Sago](https://github.com/ogham) <<ogham@bsago.me>>
  * [Brad Urani](https://github.com/bradurani)
+ * [Ceri Storey](https://github.com/cstorey)
  * [Dabo Ross](https://github.com/daboross) <<daboross@daboross.net>>
  * [Georg Brandl](https://github.com/birkenfeld) <<georg@python.org>>
  * [Paul Blouët](https://github.com/Georgi) <<paul@paulblouet.fr>>

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -326,7 +326,7 @@ impl<'a> ArgMatches<'a> {
     /// assert_eq!(m.occurrences_of("debug"), 3);
     /// assert_eq!(m.occurrences_of("flag"), 1);
     /// ```
-    pub fn occurrences_of<S: AsRef<str>>(&self, name: S) -> u8 {
+    pub fn occurrences_of<S: AsRef<str>>(&self, name: S) -> u64 {
         self.args.get(name.as_ref()).map_or(0, |a| a.occurs)
     }
 

--- a/src/args/matched_arg.rs
+++ b/src/args/matched_arg.rs
@@ -6,7 +6,7 @@ use vec_map::VecMap;
 #[derive(Debug, Clone)]
 pub struct MatchedArg {
     #[doc(hidden)]
-    pub occurs: u8,
+    pub occurs: u64,
     #[doc(hidden)]
     pub vals: VecMap<OsString>,
 }

--- a/tests/multiple_occurrences.rs
+++ b/tests/multiple_occurrences.rs
@@ -63,3 +63,14 @@ fn multiple_occurrences_of_flags_mixed() {
     assert!(m.is_present("flag"));
     assert_eq!(m.occurrences_of("flag"), 1);
 }
+
+#[test]
+fn multiple_occurrences_of_flags_large_quantity() {
+    let args : Vec<&str> = vec![""].into_iter().chain(vec!["-m"; 1024].into_iter()).collect();
+    let m = App::new("multiple_occurrences")
+                .arg(Arg::from_usage("-m --multflag 'allowed multiple flag'")
+                    .multiple(true))
+                .get_matches_from(args);
+    assert!(m.is_present("multflag"));
+    assert_eq!(m.occurrences_of("multflag"), 1024);
+}


### PR DESCRIPTION
Hi,

I often use tools with `xargs` and the like, and it's entirely possible to end up with inhumanly long sets of parameters being passed to a command. 

Without this fix, the library will panic with an arithmetic overflow in `ArgMatcher#inc_occurrence_of` when the 256th instance of the parameter is accounted for.

Thanks,