### PR TITLE
Issue 420

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="v2.0.6"></a>
+### v2.0.6 (2016-02-09)
+
+
+#### Improvements
+
+* **Positional Arguments:**  now displays value name if appropriate ([f0a99916](https://github.com/kbknapp/clap-rs/commit/f0a99916c59ce675515c6dcdfe9a40b130510908), closes [#420](https://github.com/kbknapp/clap-rs/issues/420))
+
+
 <a name="v2.0.5"></a>
 ### v2.0.5 (2016-02-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "clap"
-version = "2.0.5"
+version = "2.0.6"
 authors = ["Kevin K. <kbknapp@gmail.com>"]
 exclude = ["examples/*", "clap-tests/*", "tests/*", "benches/*", "*.png", "clap-perf/*"]
 description = "A simple to use, efficient, and full featured  Command Line Argument Parser"

--- a/src/args/arg_builder/positional.rs
+++ b/src/args/arg_builder/positional.rs
@@ -174,17 +174,44 @@ impl<'n, 'e> AnyArg<'n, 'e> for PosBuilder<'n, 'e> {
 mod test {
     use super::PosBuilder;
     use args::settings::ArgSettings;
+    use vec_map::VecMap;
 
     #[test]
-    fn posbuilder_display() {
+    fn display_mult() {
         let mut p = PosBuilder::new("pos", 1);
         p.settings.set(ArgSettings::Multiple);
 
         assert_eq!(&*format!("{}", p), "[pos]...");
+    }
 
+    #[test]
+    fn display_required() {
         let mut p2 = PosBuilder::new("pos", 1);
         p2.settings.set(ArgSettings::Required);
 
         assert_eq!(&*format!("{}", p2), "<pos>");
+    }
+
+    #[test]
+    fn display_val_names() {
+        let mut p2 = PosBuilder::new("pos", 1);
+        let mut vm = VecMap::new();
+        vm.insert(0, "file1");
+        vm.insert(1, "file2");
+        p2.val_names = Some(vm);
+
+        assert_eq!(&*format!("{}", p2), "[file1] [file2]");
+    }
+
+    #[test]
+    fn display_val_names_req() {
+        let mut p2 = PosBuilder::new("pos", 1);
+        p2.settings.set(ArgSettings::Required);
+        let mut vm = VecMap::new();
+        vm.insert(0, "file1");
+        vm.insert(1, "file2");
+        p2.val_names = Some(vm);
+
+        assert_eq!(&*format!("{}", p2), "<file1> <file2>");
     }
 }

--- a/src/args/arg_builder/positional.rs
+++ b/src/args/arg_builder/positional.rs
@@ -130,11 +130,19 @@ impl<'n, 'e> PosBuilder<'n, 'e> {
 impl<'n, 'e> Display for PosBuilder<'n, 'e> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         if self.settings.is_set(ArgSettings::Required) {
-            try!(write!(f, "<{}>", self.name));
+            if let Some(ref names) = self.val_names {
+                try!(write!(f, "{}", names.values().map(|n| format!("<{}>", n)).collect::<Vec<_>>().join(" ")));
+            } else {
+                try!(write!(f, "<{}>", self.name));
+            }
         } else {
-            try!(write!(f, "[{}]", self.name));
+            if let Some(ref names) = self.val_names {
+                try!(write!(f, "{}", names.values().map(|n| format!("[{}]", n)).collect::<Vec<_>>().join(" ")));
+            } else {
+                try!(write!(f, "[{}]", self.name));
+            }
         }
-        if self.settings.is_set(ArgSettings::Multiple) {
+        if self.settings.is_set(ArgSettings::Multiple) && self.val_names.is_none() {
             try!(write!(f, "..."));
         }
 


### PR DESCRIPTION
When value names are use, they will be displayed in help and error
messages instead of the argument name. For example, an argument named
`arg` but with the value name `FILE` will be displayed as `[FILE]`.
Likewise multiple value names will be displayed properly such as `[FILE1] [FILE2]`

Closes #420