### PR TITLE
Use ::std::result::Result to make macro hygienic.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -287,7 +287,7 @@ macro_rules! arg_enum {
         impl ::std::str::FromStr for $e {
             type Err = String;
 
-            fn from_str(s: &str) -> Result<Self,Self::Err> {
+            fn from_str(s: &str) -> ::std::result::Result<Self,Self::Err> {
                 use ::std::ascii::AsciiExt;
                 match s {
                     $(stringify!($v) |


### PR DESCRIPTION
I ran into an error using 

```
struct Error {}

pub type Result<T> = ::std::result::Result<T, Error>;

arg_enum!{
   ....
}
~~~ 

Attached is a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/473)
<!-- Reviewable:end -->
