### PR TITLE
feat(Authors Macro): adds a crate_authors macro

### DIFF
--- a/examples/19_auto_authors.rs
+++ b/examples/19_auto_authors.rs
@@ -1,0 +1,16 @@
+#[macro_use]
+extern crate clap;
+
+use clap::App;
+
+#[cfg(feature = "unstable")]
+fn main() {
+    App::new("myapp")
+        .about("does awesome things")
+       // use crate_authors! to pull the author(s) names from the Cargo.toml
+       .author(crate_authors!())
+       .get_matches();
+
+    // running the this app with the -h will display whatever author(s) are in your
+    // Cargo.toml
+}


### PR DESCRIPTION
Adds a crate_authors! macro that fetches
crate authors from a (recently added)
cargo enviromental variable populated
from the Cargo file. Like the
crate_version macro.

Closes #447