### PR TITLE
feat(Authors Macro): adds a crate_authors macro

### DIFF
--- a/examples/19_auto_authors.rs
+++ b/examples/19_auto_authors.rs
@@ -1,0 +1,23 @@
+#[macro_use]
+extern crate clap;
+
+use clap::App;
+
+#[cfg(feature = "unstable")]
+fn main() {
+    App::new("myapp")
+        .about("does awesome things")
+       // use crate_authors! to pull the author(s) names from the Cargo.toml
+       .author(crate_authors!())
+       .get_matches();
+
+    // running the this app with the -h will display whatever author(s) are in your
+    // Cargo.toml
+}
+
+#[cfg(not(feature = "unstable"))]
+fn main() {
+    // if clap is not compiled with the unstable feature, it is disabled.
+    println!("unstable feature disabled.");
+    println!("Pass --features unstable to cargo when trying this example.");
+}

--- a/examples/19_auto_authors.rs
+++ b/examples/19_auto_authors.rs
@@ -1,10 +1,9 @@
 #[macro_use]
 extern crate clap;
 
-use clap::App;
-
 #[cfg(feature = "unstable")]
 fn main() {
+    use clap::App;
     App::new("myapp")
         .about("does awesome things")
        // use crate_authors! to pull the author(s) names from the Cargo.toml

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -110,9 +110,15 @@ impl<'a, 'b> App<'a, 'b> {
         App::from(yaml)
     }
 
-    /// Sets a string of author(s) that will be displayed to the user when they request the help
-    /// information with `--help` or `-h`.
+    /// Sets a string of author(s) that will be displayed to the user when they 
+    /// request the help information with `--help` or `-h`.
     ///
+    /// **Pro-tip:** If you turn on unstable features you can use `clap`s 
+    /// convienience macro `crate_authors!` to automatically set your
+    /// application's author to the same thing as your crate at compile time. 
+    /// See the `examples/`
+    /// directory for more information
+    ///    
     /// # Examples
     ///
     /// ```no_run

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -350,7 +350,7 @@ macro_rules! arg_enum {
     };
 }
 
-/// Allows you pull the version from your Cargo.toml at compile time as
+/// Allows you to pull the version from your Cargo.toml at compile time as
 /// MAJOR.MINOR.PATCH_PKGVERSION_PRE
 ///
 /// # Examples
@@ -372,8 +372,10 @@ macro_rules! crate_version {
     };
 }
 
-/// Allows you pull the authors for the app from your Cargo.toml at compile time as 
-/// "author1 lastname. <author1@gmail.com>", "author2 lastname. <author1@gmail.com>"
+/// Allows you to pull the authors for the app from your Cargo.toml at 
+/// compile time as 
+/// "author1 lastname. <author1@example.com>",
+///     "author2 lastname. <author2@example.com>"
 ///
 /// # Examples
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -350,7 +350,7 @@ macro_rules! arg_enum {
     };
 }
 
-/// Allows you pull the version for an from your Cargo.toml at compile time as
+/// Allows you pull the version from your Cargo.toml at compile time as
 /// MAJOR.MINOR.PATCH_PKGVERSION_PRE
 ///
 /// # Examples
@@ -369,6 +369,28 @@ macro_rules! arg_enum {
 macro_rules! crate_version {
     () => {
         env!("CARGO_PKG_VERSION")
+    };
+}
+
+/// Allows you pull the authors for the app from your Cargo.toml at compile time as 
+/// "author1 lastname. <author1@gmail.com>", "author2 lastname. <author1@gmail.com>"
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[macro_use]
+/// # extern crate clap;
+/// # use clap::App;
+/// # fn main() {
+///     let m = App::new("app")
+///                 .author(crate_authors!())
+///                 .get_matches();
+/// # }
+/// ```
+#[cfg_attr(feature = "unstable", macro_export)]
+macro_rules! crate_authors {
+    () => {
+        env!("CARGO_PKG_AUTHORS")
     };
 }
 


### PR DESCRIPTION
Adds a crate_authors! macro that fetches
crate authors from a (recently added)
cargo enviromental variable populated
from the Cargo file. Like the
crate_version macro.

Closes #447 

Hopefully this fixed the previous problems.