### PR TITLE
test: adds failing alias doc test and example

### DIFF
--- a/examples/20_aliases.rs
+++ b/examples/20_aliases.rs
@@ -1,0 +1,39 @@
+extern crate clap;
+
+use clap::{App, Arg, SubCommand};
+
+fn main() {
+
+    let matches = App::new("MyApp")
+                        .subcommand(SubCommand::with_name("ls")
+                                                .aliases(&["list", "dir"])
+                                                .about("Adds files to myapp")
+                                                .version("0.1")
+                                                .author("Kevin K.")
+                                                .arg(Arg::with_name("input")
+                                                            .help("the file to add")
+                                                            .index(1)
+                                                            .required(true))
+                                                )
+                        .get_matches();
+
+    // You can check if a subcommand was used like normal
+    if matches.is_present("add") {
+        println!("'myapp add' was run.");
+    }
+
+    // You can get the independent subcommand matches (which function exactly like App matches)
+    if let Some(ref matches) = matches.subcommand_matches("add") {
+        // Safe to use unwrap() because of the required() option
+        println!("Adding file: {}", matches.value_of("input").unwrap());
+    }
+
+    // You can also match on a subcommand's name
+    match matches.subcommand_name() {
+        Some("add") => println!("'myapp add' was used"),
+        None        => println!("No subcommand was used"),
+        _           => println!("Some other subcommand was used"),
+    }
+
+    // Continued program logic goes here...
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -543,17 +543,17 @@ impl<'a, 'b> App<'a, 'b> {
     ///                 .arg(Arg::with_name("input")
     ///                             .help("the file to add")
     ///                             .index(1)
-    ///                             .required(true))
+    ///                             .required(false))
     ///             .get_matches_from(vec!["myprog", "do-tests"]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
-    pub fn aliases<S: AsRef<str> + 'b>(mut self, names: &'b [S]) -> Self {
+    pub fn aliases(mut self, names: &[&'b str]) -> Self {
         if let Some(ref mut als) = self.p.meta.aliases {
             for n in names {
-                als.push(n.as_ref());
+                als.push(n);
             }
         } else {
-            self.p.meta.aliases = Some(names.iter().map(|n| n.as_ref()).collect());
+            self.p.meta.aliases = Some(names.iter().map(|n| *n).collect::<Vec<_>>());
         }
         self
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -535,11 +535,15 @@ impl<'a, 'b> App<'a, 'b> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```rust
     /// # use clap::{App, Arg, SubCommand};
     /// let m = App::new("myprog")
     ///             .subcommand(SubCommand::with_name("test")
     ///                 .aliases(&["do-stuff", "do-tests", "tests"]))
+    ///                 .arg(Arg::with_name("input")
+    ///                             .help("the file to add")
+    ///                             .index(1)
+    ///                             .required(true))
     ///             .get_matches_from(vec!["myprog", "do-tests"]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```


### PR DESCRIPTION
Hey there,
I tried out the new aliasing feature, and they don't seem to play well with `.arg()`.
This produces a lifetime errors:

```bash
examples/20_aliases.rs:9:59: 9:74 error: borrowed value does not live long enough
examples/20_aliases.rs:9                                                 .aliases(&["list", "dir"])
                                                                                   ^~~~~~~~~~~~~~~
```