### PR TITLE
docs: makes all publicly available types viewable in docs

### DIFF
--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -506,6 +506,19 @@ impl<'a> ArgMatches<'a> {
 // commit: be5e1fa3c26e351761b33010ddbdaf5f05dbcc33
 // license: MIT - Copyright (c) 2015 The Rust Project Developers
 
+/// An iterator for getting multiple values out of an argument via the `Arg::values_of` method.
+///
+/// # Examples
+///
+/// ```rust
+/// # use clap::{App, Arg};
+/// let m = App::new("myapp")
+///     .arg(Arg::with_name("output")
+///         .takes_value(true))
+///     .get_matches_from(vec!["myapp", "something"]);
+///
+/// assert_eq!(m.value_of("output"), Some("something"));
+/// ```
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct Values<'a> {
@@ -576,6 +589,23 @@ impl<'a, V> DoubleEndedIterator for Iter<'a, V> {
     }
 }
 
+/// An iterator for getting multiple values out of an argument via the `Arg::values_of_os` method.
+/// Usage of this iterator allows values which contain invalid UTF-8 code points unlike `Values`.
+///
+/// # Examples
+///
+/// ```ignore
+/// # use clap::{App, Arg};
+/// use std::ffi::OsString;
+/// use std::os::unix::ffi::OsStrExt;
+///
+/// let m = App::new("utf8")
+///     .arg(Arg::from_usage("<arg> 'some arg'"))
+///     .get_matches_from(vec![OsString::from("myprog"),
+///                             // "Hi {0xe9}!"
+///                             OsString::from_vec(vec![b'H', b'i', b' ', 0xe9, b'!'])]);
+/// assert_eq!(&*m.value_of_os("arg").unwrap().as_bytes(), [b'H', b'i', b' ', 0xe9, b'!']);
+/// ```
 #[derive(Clone)]
 #[allow(missing_debug_implementations)]
 pub struct OsValues<'a> {

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -1,5 +1,5 @@
 pub use self::arg::Arg;
-pub use self::arg_matches::ArgMatches;
+pub use self::arg_matches::{Values, OsValues, ArgMatches};
 pub use self::arg_matcher::ArgMatcher;
 pub use self::subcommand::SubCommand;
 pub use self::arg_builder::{FlagBuilder, OptBuilder, PosBuilder};

--- a/src/args/settings.rs
+++ b/src/args/settings.rs
@@ -46,7 +46,6 @@ impl Default for ArgFlags {
 /// Various settings that apply to arguments and may be set, unset, and checked via getter/setter
 /// methods `Arg::set`, `Arg::unset`, and `Arg::is_set`
 #[derive(Debug, PartialEq, Copy, Clone)]
-#[doc(hidden)]
 pub enum ArgSettings {
     /// The argument must be used
     Required,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ extern crate vec_map;
 
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;
-pub use args::{Arg, ArgGroup, ArgMatches, ArgSettings, SubCommand};
+pub use args::{Arg, ArgGroup, ArgMatches, ArgSettings, SubCommand, Values, OsValues};
 pub use app::{App, AppSettings};
 pub use fmt::Format;
 pub use errors::{Error, ErrorKind, Result};


### PR DESCRIPTION
Some types weren't viewable in the docs, such as `Values`, `OsValues`,
and `ArgSettings`. All these types should now be browsable in the
docs page.

Relates to #505