### PR TITLE
docs: fix typos

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -90,7 +90,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// In order to use this function you must compile `clap` with the `features = ["yaml"]` in
     /// your settings for the `[dependencies.clap]` table of your `Cargo.toml`
     ///
-    /// **NOTE:** Due to how the YAML objects are built there is a convienience macro for loading
+    /// **NOTE:** Due to how the YAML objects are built there is a convenience macro for loading
     /// the YAML file at compile time (relative to the current file, like modules work). That YAML
     /// object can then be passed to this function.
     ///
@@ -102,7 +102,7 @@ impl<'a, 'b> App<'a, 'b> {
     ///
     /// # Examples
     ///
-    /// The following example shows how to load a properly formatted YAML file to build an instnace
+    /// The following example shows how to load a properly formatted YAML file to build an instance
     /// of an [`App`] struct.
     ///
     /// ```ignore
@@ -125,7 +125,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// request the help information with `--help` or `-h`.
     ///
     /// **Pro-tip:** If you turn on unstable features you can use `clap`s
-    /// convienience macro [`crate_authors!`] to automatically set your
+    /// convenience macro [`crate_authors!`] to automatically set your
     /// application's author to the same thing as your crate at compile time.
     /// See the [`examples/`]
     /// directory for more information
@@ -221,7 +221,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// Sets a string of the version number to be displayed when displaying version or help
     /// information.
     ///
-    /// **Pro-tip:** Use `clap`s convienience macro [`crate_version!`] to automatically set your
+    /// **Pro-tip:** Use `clap`s convenience macro [`crate_version!`] to automatically set your
     /// application's version to the same thing as your crate at compile time. See the [`examples/`]
     /// directory for more information
     ///
@@ -318,7 +318,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// your own.
     ///
     /// **NOTE:** Any leading `-` characters will be stripped, and only the first
-    /// non `-` chacter will be used as the [`short`] version
+    /// non `-` character will be used as the [`short`] version
     ///
     /// # Examples
     ///
@@ -344,7 +344,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// your own.
     ///
     /// **NOTE:** Any leading `-` characters will be stripped, and only the first
-    /// non `-` chacter will be used as the `short` version
+    /// non `-` character will be used as the `short` version
     ///
     /// # Examples
     ///
@@ -558,7 +558,7 @@ impl<'a, 'b> App<'a, 'b> {
         self
     }
 
-    /// A convienience method for adding a single [argument] from a usage type string. The string
+    /// A convenience method for adding a single [argument] from a usage type string. The string
     /// used follows the same rules and syntax as [`Arg::from_usage`]
     ///
     /// **NOTE:** The downside to using this method is that you can not set any additional
@@ -615,8 +615,8 @@ impl<'a, 'b> App<'a, 'b> {
 
     /// Allows adding a [`SubCommand`] alias, which function as "hidden" subcommands that
     /// automatically dispatch as if this subcommand was used. This is more efficient, and easier
-    /// than creating multiple hidden subcommands as one only needs to check for the existing of
-    /// this command, and not all vairants.
+    /// than creating multiple hidden subcommands as one only needs to check for the existence of
+    /// this command, and not all variants.
     ///
     /// # Examples
     ///
@@ -640,8 +640,8 @@ impl<'a, 'b> App<'a, 'b> {
 
     /// Allows adding [`SubCommand`] aliases, which function as "hidden" subcommands that
     /// automatically dispatch as if this subcommand was used. This is more efficient, and easier
-    /// than creating multiple hidden subcommands as one only needs to check for the existing of
-    /// this command, and not all vairants.
+    /// than creating multiple hidden subcommands as one only needs to check for the existence of
+    /// this command, and not all variants.
     ///
     /// # Examples
     ///
@@ -940,7 +940,7 @@ impl<'a, 'b> App<'a, 'b> {
     }
 
     /// Starts the parsing process, upon a failed parse an error will be displayed to the user and
-    /// the process with exit with the appropriate error code. By default this method gets all user
+    /// the process will exit with the appropriate error code. By default this method gets all user
     /// provided arguments from [`env::args_os`] in order to allow for invalid UTF-8 code points,
     /// which are legal on many platforms.
     ///
@@ -958,7 +958,7 @@ impl<'a, 'b> App<'a, 'b> {
     }
 
     /// Starts the parsing process. This method will return a [`clap::Result`] type instead of exiting
-    /// the the process on failed parse. By default this method gets matches from [`env::args_os`]
+    /// the process on failed parse. By default this method gets matches from [`env::args_os`]
     ///
     /// **NOTE:** This method WILL NOT exit when `--help` or `--version` (or short versions) are
     /// used. It will return a [`clap::Error`], where the [`kind`] is a

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -232,7 +232,7 @@ pub enum AppSettings {
     /// // running `myprog --help` will display a unified "docopt" or "getopts" style help message
     /// ```
     UnifiedHelpMessage,
-    /// Will display a message "Press [ENTER]/[RETURN] to continue..." and wait user before
+    /// Will display a message "Press [ENTER]/[RETURN] to continue..." and wait for user before
     /// exiting
     ///
     /// This is most useful when writing an application which is run from a GUI shortcut, or on
@@ -332,9 +332,9 @@ pub enum AppSettings {
     /// the [`ArgMatches`] struct.
     ///
     /// **NOTE:** Use this setting with caution, as a truly unexpected argument (i.e. one that is
-    /// *NOT* an external subcommand) will **not** cause an error and instead be treatd as a
+    /// *NOT* an external subcommand) will **not** cause an error and instead be treated as a
     /// potential subcommand. One should check for such cases manually and inform the user
-    /// appropriatly.
+    /// appropriately.
     ///
     /// # Examples
     ///

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -259,7 +259,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///
     /// ### Explicit Name
     ///
-    /// This is an optional field, if it's omitted the argumenet will use one of the additioinal
+    /// This is an optional field, if it's omitted the argument will use one of the additional
     /// fields as the name using the following priority order:
     ///
     ///  * Explicit Name (This always takes precedence when present)
@@ -424,7 +424,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///
     /// # Examples
     ///
-    /// To set `long` use a word containing valid UTF-8 codepoints. If you supply a dobule leading
+    /// To set `long` use a word containing valid UTF-8 codepoints. If you supply a double leading
     /// `--` such as `--config` they will be stripped. Hyphens in the middle of the word, however,
     /// will *not* be stripped (i.e. `config-file` is allowed)
     ///
@@ -628,9 +628,9 @@ impl<'a, 'b> Arg<'a, 'b> {
     }
 
     /// Sets args that override this arg's required setting. (i.e. this arg will be required unless
-    /// all these other argument are present).
+    /// all these other arguments are present).
     ///
-    /// **NOTE:** If you wish for the this argument to only be required if *one of* these args are
+    /// **NOTE:** If you wish for this argument to only be required if *one of* these args are
     /// present see [`Arg::required_unless_one`]
     ///
     /// # Examples
@@ -703,9 +703,9 @@ impl<'a, 'b> Arg<'a, 'b> {
     }
 
     /// Sets args that override this arg's [required] setting. (i.e. this arg will be required
-    /// unless *at least one of* these other argument are present).
+    /// unless *at least one of* these other arguments are present).
     ///
-    /// **NOTE:** If you wish for the this argument to only be required if *all of* these args are
+    /// **NOTE:** If you wish for this argument to only be required if *all of* these args are
     /// present see [`Arg::required_unless_all`]
     ///
     /// # Examples
@@ -879,7 +879,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// will override each other in POSIX style (whichever argument was specified at runtime
     /// **last** "wins")
     ///
-    /// **NOTE:** When an argument is overriden it is essentially as if it never was used, any
+    /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
     /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
     ///
     /// # Examples
@@ -893,11 +893,11 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///     .arg(Arg::from_usage("-c, --color 'third flag'")
     ///         .overrides_with("flag"))
     ///     .get_matches_from(vec!["posix", "-f", "-d", "-c"]);
-    ///                                 //    ^~~~~~~~~~~~^~~~~ flag is overriden by color
+    ///                                 //    ^~~~~~~~~~~~^~~~~ flag is overridden by color
     ///
     /// assert!(m.is_present("color"));
     /// assert!(m.is_present("debug")); // even though flag conflicts with debug, it's as if flag
-    ///                                 // was never used because it was overriden with color
+    ///                                 // was never used because it was overridden with color
     /// assert!(!m.is_present("flag"));
     /// ```
     pub fn overrides_with(mut self, name: &'a str) -> Self {
@@ -913,7 +913,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// argument will override each other in POSIX style (whichever argument was specified at
     /// runtime **last** "wins")
     ///
-    /// **NOTE:** When an argument is overriden it is essentially as if it never was used, any
+    /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
     /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
     ///
     /// # Examples
@@ -927,10 +927,10 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///     .arg(Arg::from_usage("-c, --color 'third flag'")
     ///         .overrides_with_all(&["flag", "debug"]))
     ///     .get_matches_from(vec!["posix", "-f", "-d", "-c"]);
-    ///                                 //    ^~~~~~^~~~~~~~~ flag and debug are overriden by color
+    ///                                 //    ^~~~~~^~~~~~~~~ flag and debug are overridden by color
     ///
     /// assert!(m.is_present("color")); // even though flag conflicts with color, it's as if flag
-    ///                                 // and debug were never used because they were overriden
+    ///                                 // and debug were never used because they were overridden
     ///                                 // with color
     /// assert!(!m.is_present("debug"));
     /// assert!(!m.is_present("flag"));
@@ -961,7 +961,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     ///
     /// Setting [`Arg::requires(name)`] requires that the argument be used at runtime if the
-    /// defining argument is used. If the defining argument isn't used, the other arguemnt isn't
+    /// defining argument is used. If the defining argument isn't used, the other argument isn't
     /// required
     ///
     /// ```rust
@@ -1027,7 +1027,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///
     /// Setting [`Arg::requires_all(&[arg, arg2])`] requires that all the arguments be used at
     /// runtime if the defining argument is used. If the defining argument isn't used, the other
-    /// arguemnt isn't required
+    /// argument isn't required
     ///
     /// ```rust
     /// # use clap::{App, Arg};
@@ -1091,10 +1091,10 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// * Using an equals and no space such as `-o=value` or `--option=value`
     /// * Use a short and no space such as `-ovalue`
     ///
-    /// **NOTE:** By default, args which allow [multiple values] are delimted by commas, meaning
-    /// `--option=val1,val2,val3` is is three values for the `--option` argument. If you wish to
+    /// **NOTE:** By default, args which allow [multiple values] are delimited by commas, meaning
+    /// `--option=val1,val2,val3` is three values for the `--option` argument. If you wish to
     /// change the delimiter to another character you can use [`Arg::value_delimiter(char)`],
-    /// alternatively you can delimiting values **OFF** by using [`Arg::use_delimiter(false)`]
+    /// alternatively you can turn delimiting values **OFF** by using [`Arg::use_delimiter(false)`]
     ///
     /// # Examples
     ///
@@ -1136,7 +1136,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// leave off the `index` method, and the index will be assigned in order of evaluation.
     /// Utilizing the `index` method allows for setting indexes out of order
     ///
-    /// **NOTE:** When utilized with [`Arg::multiple(true)`], only the **last** psoitional argument
+    /// **NOTE:** When utilized with [`Arg::multiple(true)`], only the **last** positional argument
     /// may be defined as multiple (i.e. with the highest index)
     ///
     /// # Panics
@@ -1188,9 +1188,9 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// **WARNING:**
     ///
     /// Setting `multiple(true)` for an [option] with no other details, allows multiple values
-    /// **and** multiple occurrences because it isn't possible to more occurrences than values for
+    /// **and** multiple occurrences because it isn't possible to have more occurrences than values for
     /// options. Because multiple values are allowed, `--option val1 val2 val3` is perfectly valid,
-    /// be careful when designing a CLI where positional arguments are expectd after a option which
+    /// be careful when designing a CLI where positional arguments are expected after a option which
     /// accepts multiple values, as `clap` will continue parsing *values* until it reaches the max
     /// or specific number of values defined, or another flag or option.
     ///
@@ -1700,11 +1700,11 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// `-f <file>` argument where you wanted up to 3 'files' you would set `.max_values(3)`, and
     /// this argument would be satisfied if the user provided, 1, 2, or 3 values.
     ///
-    /// **NOTE:** This does *not* implicitly set [`Arg::mulitple(true)`]. This is because
-    /// `-o val -o val` is multiples occurrences but a single value and `-o val1 val2` is a single
+    /// **NOTE:** This does *not* implicitly set [`Arg::multiple(true)`]. This is because
+    /// `-o val -o val` is multiple occurrences but a single value and `-o val1 val2` is a single
     /// occurence with multple values. For positional arguments this **does** set
-    /// [`Arg::multiple(true)`] because there is no way to determine the diffrence between multiple
-    /// occureces and multiple values.
+    /// [`Arg::multiple(true)`] because there is no way to determine the difference between multiple
+    /// occurences and multiple values.
     ///
     /// # Examples
     ///
@@ -1747,22 +1747,22 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooManyValues);
     /// ```
-    /// [`Arg::mulitple(true)`]: ./struct.Arg.html#method.multiple
+    /// [`Arg::multiple(true)`]: ./struct.Arg.html#method.multiple
     pub fn max_values(mut self, qty: u64) -> Self {
         self.max_vals = Some(qty);
         self
     }
 
-    /// Specifies the *minimum* number of values are for this argument. For example, if you had a
+    /// Specifies the *minimum* number of values for this argument. For example, if you had a
     /// `-f <file>` argument where you wanted at least 2 'files' you would set
     /// `.min_values(2)`, and this argument would be satisfied if the user provided, 2 or more
     /// values.
     ///
-    /// **NOTE:** This does not implicitly set [`Arg::mulitple(true)`]. This is because
-    /// `-o val -o val` is multiples occurrences but a single value and `-o val1 val2` is a single
-    /// occurence with multple values. For positional arguments this **does** set
-    /// [`Arg::multiple(true)`] because there is no way to determine the diffrence between multiple
-    /// occureces and multiple values.
+    /// **NOTE:** This does not implicitly set [`Arg::multiple(true)`]. This is because
+    /// `-o val -o val` is multiple occurrences but a single value and `-o val1 val2` is a single
+    /// occurence with multiple values. For positional arguments this **does** set
+    /// [`Arg::multiple(true)`] because there is no way to determine the difference between multiple
+    /// occurences and multiple values.
     ///
     /// # Examples
     ///
@@ -1791,7 +1791,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert_eq!(files, ["file1", "file2", "file3"]);
     /// ```
     ///
-    /// Supplying less than the mainimum number of values is an error
+    /// Supplying less than the minimum number of values is an error
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
@@ -1805,18 +1805,18 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooFewValues);
     /// ```
-    /// [`Arg::mulitple(true)`]: ./struct.Arg.html#method.multiple
+    /// [`Arg::multiple(true)`]: ./struct.Arg.html#method.multiple
     pub fn min_values(mut self, qty: u64) -> Self {
         self.min_vals = Some(qty);
         self.set(ArgSettings::TakesValue)
     }
 
-    /// Specifies whether or not an arugment should allow grouping of multiple values via a
-    /// delimter. I.e. shoulde `--option=val1,val2,val3` be parsed as three values (`val1`, `val2`,
+    /// Specifies whether or not an argument should allow grouping of multiple values via a
+    /// delimiter. I.e. should `--option=val1,val2,val3` be parsed as three values (`val1`, `val2`,
     /// and `val3`) or as a single value (`val1,val2,val3`). Defaults to using `,` (comma) as the
     /// value delimiter for all arguments that accept values (options and positional arguments)
     ///
-    /// **NOTE:** The defalt is `true`. Setting the value to `true` will reset any previous use of
+    /// **NOTE:** The default is `true`. Setting the value to `true` will reset any previous use of
     /// [`Arg::value_delimiter`] back to the default of `,` (comma).
     ///
     /// # Examples
@@ -1978,7 +1978,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     }
 
     /// Specifies the name for value of [option] or [positional] arguments inside of help
-    /// documenation. This name is cosmetic only, the name is **not** used to access arguments.
+    /// documentation. This name is cosmetic only, the name is **not** used to access arguments.
     /// This setting can be very helpful when describing the type of input the user should be
     /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
     /// use all capital letters for the value name.

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -408,7 +408,7 @@ impl<'a> ArgMatches<'a> {
     /// An ASCII art depiction may help explain this better...Using a fictional version of `git` as
     /// the demo subject. Imagine the following are all subcommands of `git` (note, the author is
     /// aware these aren't actually all subcommands in the real `git` interface, but it makes
-    /// explaination easier)
+    /// explanation easier)
     ///
     /// ```notrust
     ///              Top Level App (git)                         TOP

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -28,7 +28,7 @@ use yaml_rust::Yaml;
 /// specify that *at least one* of them is used. For this, you can create a group.
 ///
 /// Finally, you may use `ArgGroup`s to pull a value from a group of arguments when you don't care
-/// exaclty which argument was actually used at runtime.
+/// exactly which argument was actually used at runtime.
 ///
 /// # Examples
 ///
@@ -204,7 +204,7 @@ impl<'a> ArgGroup<'a> {
     /// // maybe we don't know which of the two flags was used...
     /// assert!(m.is_present("req_flags"));
     /// ```
-    /// In this next example, we show the default behavior (i.e. `multiple(false)) which is throw
+    /// In this next example, we show the default behavior (i.e. `multiple(false)) which will throw
     /// an error if more than one of the args in the group was used.
     ///
     /// ```rust

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-/// A convienience macro for loading the YAML file at compile time (relative to the current file,
+/// A convenience macro for loading the YAML file at compile time (relative to the current file,
 /// like modules work). That YAML object can then be passed to this function.
 ///
 /// # Panics

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -36,7 +36,7 @@ pub fn did_you_mean<'a, T, I>(_: &str, _: I) -> Option<&'a str>
     None
 }
 
-/// Returns a suffix that can be empty, or is the standard 'did you mean phrase
+/// Returns a suffix that can be empty, or is the standard 'did you mean' phrase
 #[cfg_attr(feature = "lints", allow(needless_lifetimes))]
 pub fn did_you_mean_suffix<'z, T, I>(arg: &str,
                                      values: I,


### PR DESCRIPTION
Just caught a couple of small typos while browsing the documentation, I believe the meaning of everything is still conveyed as intended as it's just single words.