### PR TITLE
imp(arg_enum!): allows using meta items like repr(C) with arg_enum!s

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -334,33 +334,33 @@ macro_rules! arg_enum {
             }
         });
     };
-    (#[$($m:meta),+] pub enum $e:ident { $($v:ident),+ } ) => {
+    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
-            (#[$($m),+]
+            ($(#[$($m),+])+
             pub enum $e {
-                $($v),+
+                $($v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };
-    (#[$($m:meta),+] enum $e:ident { $($v:ident),+ } ) => {
+    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*),+  } ) => {
         arg_enum!(@impls
-            (#[$($m),+]
+            ($(#[$($m),+])+
             enum $e {
-                $($v),+
+                $($v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };
-    (pub enum $e:ident { $($v:ident),+ } ) => {
+    (pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
             (pub enum $e {
-                $($v),+
+                $($v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };
-    (enum $e:ident { $($v:ident),+ } ) => {
+    (enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
             (enum $e {
-                $($v),+
+                $($v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };


### PR DESCRIPTION
One can now use more than one meta item, and things like `#[repr(C)]`

Example:

```rust

arg_enum! {
	#[repr(C)]
	#[derive(Debug)]
	pub enum MyEnum {
		A=1,
		B=2
	}
}

```

Closes #543