### PR TITLE
Fix the formatting in the completions example

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -988,7 +988,9 @@ impl<'a, 'b> App<'a, 'b> {
     ///     // normal logic continues...
     /// }
     /// ```
+    ///
     /// Next, we set up our `Cargo.toml` to use a `build.rs` build script.
+    ///
     /// ```ignore
     /// # Cargo.toml
     /// build = "build.rs"


### PR DESCRIPTION
A missing newline prevented the Cargo.toml excerpt in the `gen_completions` example from being properly formatted.