### PR TITLE
feat(Completions): one can generate a basic fish completions script at compile time

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -39,7 +39,7 @@ pub struct Parser<'a, 'b>
     pub long_list: Vec<&'b str>,
     blacklist: Vec<&'b str>,
     // A list of possible flags
-    flags: Vec<FlagBuilder<'a, 'b>>,
+    pub flags: Vec<FlagBuilder<'a, 'b>>,
     // A list of possible options
     pub opts: Vec<OptBuilder<'a, 'b>>,
     // A list of positional arguments
@@ -113,8 +113,12 @@ impl<'a, 'b> Parser<'a, 'b>
         use std::error::Error;
 
         let out_dir = PathBuf::from(od);
+        let suffix = match for_shell {
+            Shell::Bash => "_bash.sh",
+            Shell::Fish => ".fish",
+        };
 
-        let mut file = match File::create(out_dir.join(format!("{}_bash.sh", &*self.meta.bin_name.as_ref().unwrap()))) {
+        let mut file = match File::create(out_dir.join(format!("{}{}", &*self.meta.bin_name.as_ref().unwrap(), suffix))) {
             Err(why) => panic!("couldn't create bash completion file: {}",
                 why.description()),
             Ok(file) => file,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,6 +446,8 @@ mod shell {
     #[derive(Debug, Copy, Clone)]
     pub enum Shell {
         /// Generates a .sh completion file for the Bourne Again SHell (BASH)
-        Bash
+        Bash,
+        /// Generates a .fish completion file for the friendly interactive shell (fish)
+        Fish,
     }
 }


### PR DESCRIPTION
As I've mentioned in #578 , I've made my first working [fish](https://github.com/fish-shell/fish-shell) completion. 😄 

Things may work like this : 

![clap](https://cloud.githubusercontent.com/assets/2716047/16733541/88e1046c-47b4-11e6-9174-899f77db5877.png)
![clap0](https://cloud.githubusercontent.com/assets/2716047/16733433/1e9314d8-47b4-11e6-9efe-56053b706cbd.png)
![clap1](https://cloud.githubusercontent.com/assets/2716047/16733437/22b88fd4-47b4-11e6-8504-4832e3d138ae.png)
![clap2](https://cloud.githubusercontent.com/assets/2716047/16733441/2533df8e-47b4-11e6-941a-81e64522eea6.png)