### PR TITLE
Fix external subcommand name

### DIFF
--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -347,11 +347,12 @@ pub enum AppSettings {
     ///         "myprog", "subcmd", "--option", "value", "-fff", "--flag"
     ///     ]);
     ///
-    /// // All trailing arguments will be stored under the subcommand's sub-matches using a value
-    /// // of the runtime subcommand name (in this case "subcmd")
+    /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
+    /// // string argument name
     /// match m.subcommand() {
     ///     (external, Some(ext_m)) => {
-    ///          let ext_args: Vec<&str> = ext_m.values_of(external).unwrap().collect();
+    ///          let ext_args: Vec<&str> = ext_m.values_of("").unwrap().collect();
+    ///          assert_eq!(external, "subcmd");
     ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);
     ///     },
     ///     _ => {},

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -493,11 +493,12 @@ impl<'a> ArgMatches<'a> {
     ///         "myprog", "subcmd", "--option", "value", "-fff", "--flag"
     ///     ]);
     ///
-    /// // All trailing arguments will be stored under the subcommand's sub-matches using a value
-    /// // of the runtime subcommand name (in this case "subcmd")
+    /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
+    /// // string argument name
     /// match app_m.subcommand() {
     ///     (external, Some(sub_m)) => {
-    ///          let ext_args: Vec<&str> = sub_m.values_of(external).unwrap().collect();
+    ///          let ext_args: Vec<&str> = sub_m.values_of("").unwrap().collect();
+    ///          assert_eq!(external, "subcmd");
     ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);
     ///     },
     ///     _ => {},

--- a/tests/template_help.rs
+++ b/tests/template_help.rs
@@ -51,7 +51,8 @@ fn build_new_help(app: &App) -> String {
 
 fn compare_app_str(l: &App, right: &str) -> bool {
     let left = build_new_help(&l);
-    let b = left.trim() == right;
+    // Strip out any mismatching \r character on windows that might sneak in on either side
+    let b = left.trim().replace("\r", "") == right.replace("\r", "");
     if !b {
         println!("");
         println!("--> left");


### PR DESCRIPTION
Fixes issue #582 

Unfortunately, due to lifetime issues because the command line is `OsString` but the `ArgMatches` arguments are regular `String`, maintaining the same functionality of accessing subcommand arguments by the "name" of the subcommand would require some pretty significant changes. Instead, I made a breaking change and the arguments are accessible through an empty argument name. Since the name of the subcommand was always "EXTERNAL_SUBCOMMAND" previously and never the actual subcommand name, I wonder how many people were actually able to use the feature as it was?