### PR TITLE
removed unstable gate from crate_authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Here's the highlights from v2.4.0
 Here's the highlights from v2.3.0
 
 * **New Help Template Engine!**: Now you have full control over the layout of your help message. Major thanks to @hgrecco
-* **Pull crate Authors from Cargo.toml**: One can now use the `crate_authors!` macro to automatically pull the crate authors from their Cargo.toml file (requires `unstable` cargo feature to enable)
+* **Pull crate Authors from Cargo.toml**: One can now use the `crate_authors!` macro to automatically pull the crate authors from their Cargo.toml file
 * **Colored Help Messages**: Help messages can now be optionally colored (See the `AppSettings::ColoredHelp` setting). Screenshot below.
 * A bunch of bug fixes
 

--- a/examples/19_auto_authors.rs
+++ b/examples/19_auto_authors.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate clap;
 
-#[cfg(feature = "unstable")]
+use clap::App;
+
 fn main() {
-    use clap::App;
     App::new("myapp")
         .about("does awesome things")
        // use crate_authors! to pull the author(s) names from the Cargo.toml
@@ -12,11 +12,4 @@ fn main() {
 
     // running the this app with the -h will display whatever author(s) are in your
     // Cargo.toml
-}
-
-#[cfg(not(feature = "unstable"))]
-fn main() {
-    // if clap is not compiled with the unstable feature, it is disabled.
-    println!("unstable feature disabled.");
-    println!("Pass --features unstable to cargo when trying this example.");
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -125,9 +125,10 @@ impl<'a, 'b> App<'a, 'b> {
     /// Sets a string of author(s) that will be displayed to the user when they
     /// request the help information with `--help` or `-h`.
     ///
-    /// **Pro-tip:** If you turn on unstable features you can use `clap`s
-    /// convenience macro [`crate_authors!`] to automatically set your
-    /// application's author to the same thing as your crate at compile time.
+    /// **Pro-tip:** Use `clap`s convenience macro [`crate_authors!`] to automatically set your
+    /// application's author(s) to the same thing as your crate at compile time. See the [`examples/`]
+    /// directory for more information
+    ///
     /// See the [`examples/`]
     /// directory for more information
     ///
@@ -234,7 +235,7 @@ impl<'a, 'b> App<'a, 'b> {
     ///     .version("v0.1.24")
     /// # ;
     /// ```
-    /// [`crate_authors!`]: ./macro.crate_authors!.html
+    /// [`crate_version!`]: ./macro.crate_version!.html
     /// [`examples/`]: https://github.com/kbknapp/clap-rs/tree/master/examples
     pub fn version<S: Into<&'b str>>(mut self, ver: S) -> Self {
         self.p.meta.version = Some(ver.into());

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -405,7 +405,7 @@ macro_rules! crate_version {
 ///                 .get_matches();
 /// # }
 /// ```
-#[cfg_attr(feature = "unstable", macro_export)]
+#[macro_export]
 macro_rules! crate_authors {
     () => {
         env!("CARGO_PKG_AUTHORS")


### PR DESCRIPTION
The cargo feature it depends on has been available since april, I think we can make this stable now.