### PR TITLE
chore: update dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags  = "~0.7"
 vec_map   = "~0.6"
 libc      = { version = "~0.2.9",  optional = true }
 ansi_term = { version = "~0.8.0",  optional = true }
-strsim    = { version = "~0.4.0",  optional = true }
+strsim    = { version = "~0.5.1",  optional = true }
 yaml-rust = { version = "~0.3.2",  optional = true }
 clippy    = { version = "~0.0.79", optional = true }
 unicode-width = { version = "~0.1.3",  optional = true }


### PR DESCRIPTION
Fixes a panic when Jaro is called with strings each with a length of one. A `clap` user discovered this: dguo/strsim-rs#5