### PR TITLE
Fix ArgGroup example not formatted as code

### DIFF
--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -53,6 +53,7 @@ use yaml_rust::Yaml;
 /// assert_eq!(err.kind, ErrorKind::ArgumentConflict);
 /// ```
 /// This next example shows a passing parse of the same scenario
+///
 /// ```rust
 /// # use clap::{App, ArgGroup};
 /// let result = App::new("app")


### PR DESCRIPTION
Before: 
![before image](https://cloud.githubusercontent.com/assets/6709544/18002834/a7516e88-6b8a-11e6-9212-4488e447ce61.png)

After: 
![after image](https://cloud.githubusercontent.com/assets/6709544/18002850/bdc0a80a-6b8a-11e6-8887-c5cd882a0b10.png)
