### PR TITLE
Add support for wrapping help at console width on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ unicode-width = "~0.1.3"
 unicode-segmentation = "~0.1.2"
 term_size = { version = "~0.1.0", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "~0.2.2"
+winapi = "~0.2.8"
+
 [dev-dependencies]
 regex = "~0.1.69"
 

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -16,7 +16,40 @@ use fmt::{Format, Colorizer};
 
 #[cfg(all(feature = "wrap_help", not(target_os = "windows")))]
 use term_size;
-#[cfg(any(not(feature = "wrap_help"), target_os = "windows"))]
+#[cfg(all(feature = "wrap_help", target_os = "windows"))]
+mod term_size {
+    use kernel32::{GetConsoleScreenBufferInfo, GetStdHandle};
+    use winapi::{CONSOLE_SCREEN_BUFFER_INFO, COORD, SMALL_RECT, STD_OUTPUT_HANDLE};
+
+    pub fn dimensions() -> Option<(usize, usize)> {
+        let null_coord = COORD{
+            X: 0,
+            Y: 0,
+        };
+        let null_smallrect = SMALL_RECT{
+            Left: 0,
+            Top: 0,
+            Right: 0,
+            Bottom: 0,
+        };
+
+        let stdout_h = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+        let mut console_data = CONSOLE_SCREEN_BUFFER_INFO{
+            dwSize: null_coord,
+            dwCursorPosition: null_coord,
+            wAttributes: 0,
+            srWindow: null_smallrect,
+            dwMaximumWindowSize: null_coord,
+        };
+
+        if unsafe { GetConsoleScreenBufferInfo(stdout_h, &mut console_data) } != 0 {
+            Some(((console_data.srWindow.Right - console_data.srWindow.Left) as usize, (console_data.srWindow.Bottom - console_data.srWindow.Top) as usize))
+        } else {
+            None
+        }
+    }
+}
+#[cfg(not(feature = "wrap_help"))]
 mod term_size {
     pub fn dimensions() -> Option<(usize, usize)> {
         None

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -530,9 +530,9 @@ impl<'a, 'b> App<'a, 'b> {
     /// Sets the terminal width at which to wrap help messages. Defaults to `120`. Using `0` will
     /// ignore terminal widths and use source formatting.
     ///
-    /// `clap` automatically tries to determine the terminal width on Unix, Linux, and OSX if the
-    /// `wrap_help` cargo "feature" has been used while compiling. If the terminal width cannot be
-    /// determined, `clap` defaults to `120`.
+    /// `clap` automatically tries to determine the terminal width on Unix, Linux, OSX and Windows
+    /// if the `wrap_help` cargo "feature" has been used while compiling. If the terminal width
+    /// cannot be determined, `clap` defaults to `120`.
     ///
     /// **NOTE:** This setting applies globally and *not* on a per-command basis.
     ///
@@ -540,9 +540,9 @@ impl<'a, 'b> App<'a, 'b> {
     ///
     /// # Platform Specific
     ///
-    /// Only Unix, Linux, and OSX support automatic determination of terminal width. Even on those
-    /// platforms, this setting is useful if for any reason the terminal width cannot be
-    /// determined.
+    /// Only Unix, Linux, OSX and Windows support automatic determination of terminal width.
+    /// Even on those platforms, this setting is useful if for any reason the terminal width
+    /// cannot be determined.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,10 @@ extern crate vec_map;
 #[cfg(feature = "wrap_help")]
 extern crate term_size;
 extern crate unicode_segmentation;
+#[cfg(target_os = "windows")]
+extern crate kernel32;
+#[cfg(target_os = "windows")]
+extern crate winapi;
 
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;


### PR DESCRIPTION
Had to revert many formatting changes, which means your code is unformatted despite the presence of `rustfmt.toml` at repo root, you should global format.

Closes #455