### PR TITLE
Fix documentation formatting for App::template()

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -364,20 +364,22 @@ impl<'a, 'b> App<'a, 'b> {
 
     /// Sets the help template to be used, overriding the default format.
     ///
-    /// Tags arg given inside curly brackets:
+    /// Tags arg given inside curly brackets.
+    ///
     /// Valid tags are:
-    ///     * `{bin}`         - Binary name.
-    ///     * `{version}`     - Version number.
-    ///     * `{author}`      - Author information.
-    ///     * `{usage}`       - Automatically generated or given usage string.
-    ///     * `{all-args}`    - Help for all arguments (options, flags, positionals arguments,
-    ///                         and subcommands) including titles.
-    ///     * `{unified}`     - Unified help for options and flags.
-    ///     * `{flags}`       - Help for flags.
-    ///     * `{options}`     - Help for options.
-    ///     * `{positionals}` - Help for positionals arguments.
-    ///     * `{subcommands}` - Help for subcommands.
-    ///     * `{after-help}`  - Help for flags.
+    ///
+    ///   * `{bin}`         - Binary name.
+    ///   * `{version}`     - Version number.
+    ///   * `{author}`      - Author information.
+    ///   * `{usage}`       - Automatically generated or given usage string.
+    ///   * `{all-args}`    - Help for all arguments (options, flags, positionals arguments,
+    ///                       and subcommands) including titles.
+    ///   * `{unified}`     - Unified help for options and flags.
+    ///   * `{flags}`       - Help for flags.
+    ///   * `{options}`     - Help for options.
+    ///   * `{positionals}` - Help for positionals arguments.
+    ///   * `{subcommands}` - Help for subcommands.
+    ///   * `{after-help}`  - Help for flags.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Before:
![before image](https://cloud.githubusercontent.com/assets/6709544/18005226/fb018816-6b98-11e6-893c-31ba84ff0bc1.png)

After:
![after image](https://cloud.githubusercontent.com/assets/6709544/18005231/0f76b5fa-6b99-11e6-89f9-5cca910d5b98.png)