### PR TITLE
imp(YAML): supports setting Arg::require_delimiter from YAML

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -164,6 +164,7 @@ impl<'a, 'b> Arg<'a, 'b> {
                 "min_values" => yaml_to_u64!(a, v, min_values),
                 "value_name" => yaml_to_str!(a, v, value_name),
                 "use_delimiter" => yaml_to_bool!(a, v, use_delimiter),
+                "require_delimiter" => yaml_to_bool!(a, v, require_delimiter),
                 "value_delimiter" => yaml_to_str!(a, v, value_delimiter),
                 "required_unless" => yaml_to_str!(a, v, required_unless),
                 "display_order" => yaml_to_usize!(a, v, display_order),

--- a/tests/app.yml
+++ b/tests/app.yml
@@ -59,6 +59,11 @@ args:
         multiple: true
         help: Tests mutliple values, not mult occs
         value_names: [one, two]
+    - multvalsdelim:
+        long: multvalsdelim
+        help: Tests mutliple values with required delimiter
+        multiple: true
+        require_delimiter: true
     - minvals2:
         long: minvals2
         multiple: true


### PR DESCRIPTION
Seems this is missing from 920b559.