### PR TITLE
WiP: Return UnrecognizedSubcommand when it's obvious.

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -673,10 +673,12 @@ impl<'a, 'b> Parser<'a, 'b>
                                     return Err(
                                         Error::unrecognized_subcommand(
                                             cmd.to_string_lossy().into_owned(),
-                                            self.meta
-                                                .bin_name
-                                                .as_ref()
-                                                .unwrap_or(&self.meta.name),
+                                            format!("Usage:\n\t
+                                                         {} help <subcommands>...\n",
+                                                    match self.meta.bin_name {
+                                                        Some(ref name) => name,
+                                                        None => &self.meta.name,
+                                                    }),
                                             self.color()));
                                 }
                                 bin_name = format!("{} {}",
@@ -717,6 +719,13 @@ impl<'a, 'b> Parser<'a, 'b>
                                                              .unwrap_or(&self.meta.name),
                                                          &*self.create_current_usage(matcher),
                                                          self.color()));
+                } else if self.positionals.is_empty() &&
+                          !self.subcommands.is_empty() {
+                    return Err(
+                        Error::unrecognized_subcommand(
+                             arg_os.to_string_lossy().into_owned(),
+                             &*self.create_current_usage(matcher),
+                             self.color()));
                 }
             }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -552,9 +552,9 @@ impl Error {
     }
 
     #[doc(hidden)]
-    pub fn unrecognized_subcommand<S, N>(subcmd: S, name: N, color: fmt::ColorWhen) -> Self
+    pub fn unrecognized_subcommand<S, U>(subcmd: S, usage: U, color: fmt::ColorWhen) -> Self
         where S: Into<String>,
-              N: Display
+              U: Display
     {
         let s = subcmd.into();
         let c = fmt::Colorizer {
@@ -563,13 +563,11 @@ impl Error {
         };
         Error {
             message: format!("{} The subcommand '{}' wasn't recognized\n\n\
-                            {}\n\t\
-                                {} help <subcommands>...\n\n\
+                            {}\n\
                             For more information try {}",
                              c.error("error:"),
                              c.warning(&*s),
-                             c.warning("USAGE:"),
-                             name,
+                             usage,
                              c.good("--help")),
             kind: ErrorKind::UnrecognizedSubcommand,
             info: Some(vec![s]),


### PR DESCRIPTION
= If there are subcommands but no positional arguments
Previously `UnknownArgument` was returned.

WiP because I don't really understand the code and might have gotten the conditions wrong.

This might be a breaking change and also affects error message from `.get_matches()`.
