### PR TITLE
fix(yaml-example): inconsistent args

### DIFF
--- a/examples/17_yaml.rs
+++ b/examples/17_yaml.rs
@@ -36,8 +36,8 @@ fn main() {
     // see that it works...
     if let Some(mode) = m.value_of("mode") {
         match mode {
-            "fast" => println!("We're really going now!"),
-            "slow" => println!("Awwww, too slow :("),
+            "vi" => println!("You are using vi"),
+            "emacs" => println!("You are using emacs..."),
             _      => unreachable!()
         }
     } else {


### PR DESCRIPTION
change yaml example to be consistent with its configuration

fix #707, #708