### PR TITLE
Add App::app_name() getter

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -83,6 +83,16 @@ impl<'a, 'b> App<'a, 'b> {
         App { p: Parser::with_name(n.into()) }
     }
 
+    /// Get the name of the app
+    pub fn get_name(&self) -> &str {
+        &self.p.meta.name
+    }
+
+    /// Get the name of the binary
+    pub fn get_bin_name(&self) -> Option<&str> {
+        self.p.meta.bin_name.as_ref().map(|s| s.as_str())
+    }
+
     /// Creates a new instance of an application requiring a name, but uses the [`crate_authors!`]
     /// and [`crate_version!`] macros to fill in the [`App::author`] and [`App::version`] fields.
     ///


### PR DESCRIPTION
This is a proposal... I would like to have this for [imag](https://github.com/matthiasbeyer/imag) ([this PR](https://github.com/matthiasbeyer/imag/pull/826)).

If this is not a good idea for some reason, I will rewrite my abstractions,... but this would be the easy way for me, so I propose this! :smile: 