### PR TITLE
Support --("hyphenated-name") syntax for defining long arg names in clap_app!

### DIFF
--- a/examples/18_builder_macro.rs
+++ b/examples/18_builder_macro.rs
@@ -27,6 +27,7 @@ fn main() {
         (author: "Alice")
         (about: "Does awesome things")
         (@arg config: -c --config <conf> #{1, 2} {file_exists} "Sets a custom config file")
+        (@arg proxyHostname: --("proxy-hostname") +takes_value "Sets the hostname of the proxy to use")
         (@arg input: * "Input file")
         (@group test =>
             (@attributes +required)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -478,6 +478,9 @@ macro_rules! clap_app {
 // No more tokens to munch
     (@arg ($arg:expr) $modes:tt) => { $arg };
 // Shorthand tokens influenced by the usage_string
+    (@arg ($arg:expr) $modes:tt --($long:expr) $($tail:tt)*) => {
+        clap_app!{ @arg ($arg.long($long)) $modes $($tail)* }
+    };
     (@arg ($arg:expr) $modes:tt --$long:ident $($tail:tt)*) => {
         clap_app!{ @arg ($arg.long(stringify!($long))) $modes $($tail)* }
     };


### PR DESCRIPTION
See #321

---

If the syntax style `("string")` is acceptable, it could be done for the other items that #321 asks long names for.