### PR TITLE
Make `update-contributors` a quiet recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,12 +1,12 @@
-update-contributors:
-	@echo 'Removing old CONTRIBUTORS.md'
-	@mv CONTRIBUTORS.md CONTRIBUTORS.md.bak
-	@echo 'Downloading a list of new contributors'
-	@echo "The following is a list of contributors in alphabetical order:" > CONTRIBUTORS.md
-	@echo "" >> CONTRIBUTORS.md
-	@echo "" >> CONTRIBUTORS.md
-	@githubcontrib --owner kbknapp --repo clap-rs --sha master --cols 6 --format md --showlogin true --sortBy login >> CONTRIBUTORS.md
-	@rm CONTRIBUTORS.md.bak
+@update-contributors:
+	echo 'Removing old CONTRIBUTORS.md'
+	mv CONTRIBUTORS.md CONTRIBUTORS.md.bak
+	echo 'Downloading a list of new contributors'
+	echo "The following is a list of contributors in alphabetical order:" > CONTRIBUTORS.md
+	echo "" >> CONTRIBUTORS.md
+	echo "" >> CONTRIBUTORS.md
+	githubcontrib --owner kbknapp --repo clap-rs --sha master --cols 6 --format md --showlogin true --sortBy login >> CONTRIBUTORS.md
+	rm CONTRIBUTORS.md.bak
 
 run-test TEST:
 	cargo test --test {{TEST}}


### PR DESCRIPTION
I noticed that this is a common pattern in justfiles, recipes that
run a lot of commands and prefix every line with `@` so that
only output is printed.

So I added quiet recipes, which are recipes where the recipe name
is prefixed with a `@`.

Inside quiet recipes the usual meaning of `@` is inverted. Only
lines starting with `@` are echoed.

This diff makes the `update-contributors` recipe a quiet recipe,
and gets rid of all those unsightly `@`s.

PS I just added this in v0.2.21, so you'll need to install the latest version
from crates.io to test.

PPS Thanks for using just! I was super excited to see a justfile in this repo,
since I'm a huge fan of clap.