### PR TITLE
docs: fix broken docs links

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -2339,10 +2339,10 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert!(m.is_present("opt"));
     /// assert_eq!(m.occurrences_of("opt"), 1);
     /// ```
-    /// [`ArgMatches::occurrences_of`]: /struct.ArgMatches.html#method.occurrences_of
+    /// [`ArgMatches::occurrences_of`]: ./struct.ArgMatches.html#method.occurrences_of
     /// [`ArgMatches::value_of`]: ./struct.ArgMatches.html#method.value_of
-    /// [`Arg::takes_value(true)`]: /struct.Arg.html#method.takes_value
-    /// [`ArgMatches::is_present`]: /struct.ArgMatches.html#method.is_present
+    /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
+    /// [`ArgMatches::is_present`]: ./struct.ArgMatches.html#method.is_present
     pub fn default_value(mut self, val: &'a str) -> Self {
         self.setb(ArgSettings::TakesValue);
         self.default_val = Some(val);


### PR DESCRIPTION
These links are relative to the root of the server instead of the current file. This breaks causes them to be broken on docs.rs.