### PR TITLE
Use try!() instead of ? operator, for older compilers

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -167,7 +167,7 @@ impl<'a> Help<'a> {
     pub fn write_help(&mut self, parser: &Parser) -> ClapResult<()> {
         debugln!("fn=Help::write_help;");
         if let Some(h) = parser.meta.help_str {
-            write!(self.writer, "{}", h).map_err(Error::from)?;
+            try!(write!(self.writer, "{}", h).map_err(Error::from));
         } else if let Some(tmpl) = parser.meta.template {
             try!(self.write_templated_help(&parser, tmpl));
         } else {


### PR DESCRIPTION
This is a proposal.

Some distros (yes, I'm using the distro rustc because my distro has some benefits over using the rustup infrastructure) do not yet have the newest compiler.

I therefor propose to stay with `try!()` instead of `?` for maybe two weeks or so, maybe even a bit more, until all distros have updated their version of `rustc`.