### PR TITLE
imp(Completions): adds fallbacks to Bash completions

### DIFF
--- a/src/completions/bash.rs
+++ b/src/completions/bash.rs
@@ -58,7 +58,7 @@ impl<'a, 'b> BashGen<'a, 'b> {
     esac
 }}
 
-complete -F _{name} {name}
+complete -F _{name} -o bashdefault -o default {name}
 ",
                    name = self.p.meta.bin_name.as_ref().unwrap(),
                    name_opts = self.all_options_for_path(self.p.meta.bin_name.as_ref().unwrap()),

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -21,5 +21,5 @@ fn test_generation() {
     let last_line = string.lines().rev().nth(0).unwrap();
 
     assert_eq!(first_line, "_myapp() {");
-    assert_eq!(last_line, "complete -F _myapp myapp");
+    assert_eq!(last_line, "complete -F _myapp -o bashdefault -o default myapp");
 }


### PR DESCRIPTION
With these options, in case the completion function cannot provide suggestions, Bash will perform its default completions, based on e.g. files, directories, and variable names.

This is particularly noticeable in tools that operate on paths, like ripgrep: when I type `rg should_panic te<TAB>`, I want the shell to autocomplete `tests/`, but right now the completion script will simply beep without any suggestions.