### PR TITLE
Add no_cargo feature to disable Cargo-env-var-dependent macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ unstable    = [] # for building with unstable clap features (doesn't require nig
 nightly     = [] # for building with unstable Rust features (currently none)
 lints       = ["clippy"] # Requires nightly Rust
 debug       = [] # Enables debug messages
+no_cargo    = [] # Enable if you're not using Cargo, disables Cargo-env-var-dependent macros
 
 [profile.release]
 opt-level = 3

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -104,8 +104,8 @@ impl<'a, 'b> App<'a, 'b> {
     #[deprecated(since="2.14.1", note="Can never work; use explicit App::author() and App::version() calls instead")]
     pub fn with_defaults<S: Into<String>>(n: S) -> Self {
         let mut a = App { p: Parser::with_name(n.into()) };
-        a.p.meta.author = Some(crate_authors!());
-        a.p.meta.version = Some(crate_version!());
+        a.p.meta.author = Some("Kevin K. <kbknapp@gmail.com>");
+        a.p.meta.version = Some("2.19.2");
         a
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -385,6 +385,7 @@ macro_rules! arg_enum {
 ///                 .get_matches();
 /// # }
 /// ```
+#[cfg(not(feature="no_cargo"))]
 #[macro_export]
 macro_rules! crate_version {
     () => {
@@ -413,6 +414,7 @@ macro_rules! crate_version {
 ///             .get_matches();
 /// # }
 /// ```
+#[cfg(not(feature="no_cargo"))]
 #[macro_export]
 macro_rules! crate_authors {
     ($sep:expr) => {{


### PR DESCRIPTION
For example, given:

```toml
clap = { path = "t:/clap-rs" }
```

The macros `crate_version!()` and `crate_authors!()` exist, so the crate compiles without errors:

```
   Compiling https v0.2.0 (file:///P:/Rust/http)
    Finished debug [unoptimized + debuginfo] target(s) in 6.93 secs
    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
[Finished in 7.5s]
```

But, adding the `no_cargo` feature:

```toml
clap = { path = "t:/clap-rs", features = ["no_cargo"] }
```

The macros are removed, so the crate fails to compile:

```
   Compiling clap v2.19.2 (file:///T:/clap-rs)
   Compiling https v0.2.0 (file:///P:/Rust/http)
error: macro undefined: 'crate_version!'
  --> src\options.rs:40:22
   |
40 |             .version(crate_version!())
   |                      ^^^^^^^^^^^^^

error: macro undefined: 'crate_authors!'
  --> src\options.rs:41:21
   |
41 |             .author(crate_authors!())
   |                     ^^^^^^^^^^^^^

error: aborting due to 2 previous errors

error: Could not compile `https`.
```

Closes #783 