### PR TITLE
Explain how `ArgRequiredElseHelp` and `default_value` interact

### DIFF
--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -297,6 +297,9 @@ pub enum AppSettings {
     ///
     /// **NOTE:** [`SubCommand`]s count as arguments
     ///
+    /// **NOTE:** Setting [`Arg::default_value`] effectively disables this option as it will
+    /// ensure that some argument is always present. 
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -306,6 +309,7 @@ pub enum AppSettings {
     /// # ;
     /// ```
     /// [`SubCommand`]: ./struct.SubCommand.html
+    /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
     ArgRequiredElseHelp,
 
     /// Uses colorized help messages.

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -2775,6 +2775,9 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///
     /// **NOTE:** This implicitly sets [`Arg::takes_value(true)`].
     ///
+    /// **NOTE:** This setting effectively disables `AppSettings::ArgRequiredElseHelp` if used in
+    /// conjuction as it ensures that some argument will always be present.
+    ///
     /// # Examples
     ///
     /// First we use the default value without providing any value at runtime.


### PR DESCRIPTION
When calling the executable without arguments one expects a help message. However, if even one argument has a default value, the validation step of the parser will always see at least one argument, and therefore report success. This effectively disables the settings.