### PR TITLE
docs: fix link from app_from_crate! to crate_authors!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -495,7 +495,7 @@ macro_rules! crate_name {
 ///
 /// Equivalent to using the `crate_*!` macros with their respective fields.
 ///
-/// Provided separator is for the [macro.crate_authors.html](`crate_authors!`) macro,
+/// Provided separator is for the [`crate_authors!`](macro.crate_authors.html) macro,
 /// refer to the documentation therefor.
 ///
 /// # Examples


### PR DESCRIPTION
In the link from `app_from_crate!` to `crate_authors!`, the link text and address are swapped.