### PR TITLE
Relax dependency version constraints.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ A simple to use, efficient, and full featured  Command Line Argument Parser
 """
 
 [dependencies]
-bitflags              = "=0.7.0"
-vec_map               = "=0.6.0"
-unicode-width         = "=0.1.4"
+bitflags              = "0.7.0"
+vec_map               = "0.6.0"
+unicode-width         = "0.1.4"
 unicode-segmentation  = "1.0.1"
-strsim    = { version = "=0.6.0",  optional = true }
-ansi_term = { version = "=0.9.0",  optional = true }
-term_size = { version = "=0.2.1",  optional = true }
-libc      = { version = "=0.2.18",  optional = true }
-yaml-rust = { version = "=0.3.5",  optional = true }
+strsim    = { version = "0.6.0",  optional = true }
+ansi_term = { version = "0.9.0",  optional = true }
+term_size = { version = "0.2.1",  optional = true }
+libc      = { version = "0.2.18",  optional = true }
+yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.104", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
It's good practice for a library not to depend on exact versions of any other libraries, so that downstream programs are able to update dependencies they have in common at their leisure.

This is described in the Cargo documentation at:
http://doc.crates.io/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries

An example of the problem an exact version depedency creates can be seen at https://gist.github.com/jimmycuadra/ac26eca5f11960c357d6fba841640f2f.

This patch modifies Cargo.toml to allow semver-compatible updates to clap's dependencies.