### PR TITLE
Fix finding required arguments in group arguments

### DIFF
--- a/src/app/macros.rs
+++ b/src/app/macros.rs
@@ -113,7 +113,7 @@ macro_rules! _handle_group_reqs{
             debugln!("_handle_group_reqs!:iter: grp={}, found={:?}", grp.name, found);
             if found {
                 for i in (0 .. $me.required.len()).rev() {
-                    let should_remove = grp.args.contains(&grp.args[i]);
+                    let should_remove = grp.args.contains(&$me.required[i]);
                     if should_remove { $me.required.swap_remove(i); }
                 }
                 debugln!("_handle_group_reqs!:iter: Adding args from group to blacklist...{:?}", grp.args);


### PR DESCRIPTION
This fixes #827. The problem was that the check `grp.args.contains(&grp.args[i])` was a) trivially fulfilled (of course `grp.args[i]` is contained in `grp.args`) and b) causing an out-of-bounds error, since the indices were taken from `.required.len()`.

With this change the argument in the group will be removed from the list of required arguments, as intended.