### PR TITLE
Fix wrapping bugs

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -957,7 +957,7 @@ fn wrap_help(help: &mut String, longest_w: usize, avail_chars: usize) {
             j = prev_space;
             debugln!("Help::wrap_help:iter: prev_space={}, j={}", prev_space, j);
             debugln!("Help::wrap_help:iter: Removing...{}", j);
-            debugln!("Help::wrap_help:iter: Char at {}...{}", j, &help[j..j]);
+            debugln!("Help::wrap_help:iter: Char at {}: {:?}", j, &help[j..j+1]);
             help.remove(j);
             help.insert(j, '\n');
         }

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -948,7 +948,7 @@ fn wrap_help(help: &mut String, longest_w: usize, avail_chars: usize) {
                     continue;
                 }
                 debugln!("Help::wrap_help:iter: Reached the end of the line and we're over...");
-            } else if str_width(&help[j..idx]) < avail_chars {
+            } else if str_width(&help[j..idx]) <= avail_chars {
                 debugln!("Help::wrap_help:iter: Space found with room...");
                 prev_space = idx;
                 continue;

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -960,8 +960,21 @@ fn wrap_help(help: &mut String, longest_w: usize, avail_chars: usize) {
             debugln!("Help::wrap_help:iter: Char at {}: {:?}", j, &help[j..j+1]);
             help.remove(j);
             help.insert(j, '\n');
+            prev_space = idx;
         }
     } else {
         sdebugln!("No");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::wrap_help;
+
+    #[test]
+    fn wrap_help_last_word() {
+        let mut help = String::from("foo bar baz");
+        wrap_help(&mut help, 3, 5);
+        assert_eq!(help, "foo\nbar\nbaz");
     }
 }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -148,6 +148,19 @@ OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
     -p, --pos <VAL>      Some vals [values: fast, slow]";
 
+static FINAL_WORD_WRAPPING: &'static str = "ctest 0.1
+
+USAGE:
+    ctest
+
+FLAGS:
+    -h, --help
+            Prints help
+            information
+    -V, --version
+            Prints
+            version information";
+
 static OLD_NEWLINE_CHARS: &'static str = "ctest 0.1
 
 USAGE:
@@ -407,6 +420,12 @@ fn issue_626_variable_panic() {
                .takes_value(true))
             .get_matches_from_safe(vec!["ctest", "--help"]);
     }
+}
+
+#[test]
+fn final_word_wrapping() {
+    let app = App::new("ctest").version("0.1").set_term_width(24);
+    assert!(test::compare_output(app, "ctest --help", FINAL_WORD_WRAPPING, false));
 }
 
 #[test]

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -113,9 +113,8 @@ OPTIONS:
                          latte, cappuccino, espresso), tea, and other
                          hot beverages. Some coffeehouses also serve
                          cold beverages such as iced coffee and iced
-                         tea. Many cafés also serve some type of
-                         food, such as light snacks, muffins, or
-                         pastries.";
+                         tea. Many cafés also serve some type of food,
+                         such as light snacks, muffins, or pastries.";
 
 static ISSUE_626_PANIC: &'static str = "ctest 0.1
 

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -159,7 +159,8 @@ FLAGS:
             information
     -V, --version
             Prints
-            version information";
+            version
+            information";
 
 static OLD_NEWLINE_CHARS: &'static str = "ctest 0.1
 


### PR DESCRIPTION
I've been working towards integrating my [textwrap][1] crate and along the way, I found some small problems in the existing `wrap_help` function in clap. I basically added new code that calls both `textwrap::fill` and `wrap_help` and panicked on any difference:
```
fn wrap_help(help: &mut String, longest_w: usize, avail_chars: usize) {
    let input = help.clone();
    let mut old = help.clone();
    old_wrap_help(&mut old, longest_w, avail_chars);

    let mut wrapped = String::with_capacity(help.len());
    for (i, line) in help.lines().enumerate() {
        if i > 0 {
            wrapped.push('\n');
        }
        wrapped.push_str(&textwrap::fill(line, avail_chars));
    }

    // TODO: move up, This keeps old behavior of not wrapping at all
    // if one of the words would overflow the line
    if longest_w < avail_chars {
        *help = wrapped;
    }

    if *old != *help {
        println!("********************************");
        println!("longest_w: {}, avail_chars: {}", longest_w, avail_chars);
        println!("help: {:3} bytes: {:?}", input.len(), input);
        println!("old:  {:3} bytes: {:?}", old.len(), old);
        println!("new:  {:3} bytes: {:?}", help.len(), help);
        println!("********************************");
        panic!("bad wrap");
    }
}

fn old_wrap_help(help: &mut String, longest_w: usize, avail_chars: usize) {
    // ... as before
```

This PR fixes two small problems discovered this way, one of which became #828.

[1]: https://crates.io/crates/textwrap