### PR TITLE
Add missing fragment specifier to a clap_app! rule.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -684,7 +684,7 @@ macro_rules! clap_app {
         clap_app!{ @arg ($arg) $modes +required $($tail)* }
     };
 // !foo -> .foo(false)
-    (@arg ($arg:expr) $modes:tt !$ident $($tail:tt)*) => {
+    (@arg ($arg:expr) $modes:tt !$ident:ident $($tail:tt)*) => {
         clap_app!{ @arg ($arg.$ident(false)) $modes $($tail)* }
     };
 // +foo -> .foo(true)


### PR DESCRIPTION
Introduced in #238, this bug affects both `clap` `1.*` and `2.*` and was found by rust-lang/rust#39419.
I'd suggest releasing not only `2.20.5`, but also `1.5.6`, to cover downstream crates still on `1.5.5`.