### PR TITLE
refactor: use the atty crate for isatty() detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ term_size = { version = "0.2.2",  optional = true }
 libc      = { version = "0.2.20",  optional = true }
 yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.112", optional = true }
+atty      = { version = "0.2.2",  optional = true }
 
 [dev-dependencies]
 regex = "~0.1.80"
@@ -33,7 +34,7 @@ regex = "~0.1.80"
 [features]
 default     = ["suggestions", "color", "wrap_help"]
 suggestions = ["strsim"]
-color       = ["ansi_term", "libc"]
+color       = ["ansi_term", "atty"]
 wrap_help   = ["libc", "term_size"]
 yaml        = ["yaml-rust"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -5,18 +5,8 @@ use ansi_term::ANSIString;
 use ansi_term::Colour::{Green, Red, Yellow};
 
 #[cfg(feature = "color")]
-use libc;
+use atty;
 use std::fmt;
-
-#[cfg(all(feature = "color", not(target_os = "windows")))]
-const STDERR: i32 = libc::STDERR_FILENO;
-#[cfg(all(feature = "color", not(target_os = "windows")))]
-const STDOUT: i32 = libc::STDOUT_FILENO;
-
-#[cfg(target_os = "windows")]
-const STDERR: i32 = 0;
-#[cfg(target_os = "windows")]
-const STDOUT: i32 = 0;
 
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -29,8 +19,12 @@ pub enum ColorWhen {
 #[cfg(feature = "color")]
 pub fn is_a_tty(stderr: bool) -> bool {
     debugln!("is_a_tty: stderr={:?}", stderr);
-    let fd = if stderr { STDERR } else { STDOUT };
-    unsafe { libc::isatty(fd) != 0 }
+    let stream = if stderr {
+        atty::Stream::Stderr
+    } else {
+        atty::Stream::Stdout
+    };
+    atty::is(stream)
 }
 
 #[cfg(not(feature = "color"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@
 //! #### Features enabled by default
 //! 
 //! * **"suggestions"**: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
-//! * **"color"**: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term` and `libc`)
+//! * **"color"**: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term` and `atty`)
 //! * **"wrap_help"**: Wraps the help at the actual terminal width when available, instead of 120 chracters. (builds dependency `term_size`, and `libc`)
 //! 
 //! To disable these, add this to your `Cargo.toml`:
@@ -533,7 +533,7 @@ extern crate strsim;
 extern crate ansi_term;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;
-#[cfg(any(feature = "wrap_help", feature = "color"))]
+#[cfg(feature = "wrap_help")]
 extern crate libc;
 extern crate unicode_width;
 #[macro_use]
@@ -542,6 +542,8 @@ extern crate vec_map;
 #[cfg(feature = "wrap_help")]
 extern crate term_size;
 extern crate unicode_segmentation;
+#[cfg(feature = "color")]
+extern crate atty;
 
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;


### PR DESCRIPTION
Not only does this remove some unsafe code from clap itself, `atty` does the right thing on Windows too. This isn't relevant now since we don't currently support colorized output on Windows, but will come in handy if/when we implement that feature (#836).