### PR TITLE
fix(help): don't show ARGS when there are only hidden positional args

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -195,9 +195,7 @@ impl<'a> Help<'a> {
             if arg.longest_filter() {
                 self.longest = cmp::max(self.longest, arg.to_string().len());
             }
-            if !arg.is_set(ArgSettings::Hidden) {
-                arg_v.push(arg)
-            }
+            arg_v.push(arg)
         }
         let mut first = true;
         for arg in arg_v {
@@ -541,7 +539,7 @@ impl<'a> Help<'a> {
     pub fn write_all_args(&mut self, parser: &Parser) -> ClapResult<()> {
         debugln!("Help::write_all_args;");
         let flags = parser.has_flags();
-        let pos = parser.has_positionals();
+        let pos = parser.positionals().filter(|arg| !arg.is_set(ArgSettings::Hidden)).count() > 0;
         let opts = parser.has_opts();
         let subcmds = parser.has_subcommands();
 

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -532,7 +532,7 @@ impl<'a, 'b> Parser<'a, 'b>
 
     #[inline]
     pub fn has_positionals(&self) -> bool { !self.positionals.is_empty() }
-
+    
     #[inline]
     pub fn has_subcommands(&self) -> bool { !self.subcommands.is_empty() }
 

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -5,12 +5,12 @@ use clap::{App, Arg};
 
 include!("../clap-test.rs");
 
-static HIDDEN_ARGS: &'static str = "test 1.3
+static HIDDEN_ARGS: &'static str = "test 1.4
 Kevin K.
 tests stuff
 
 USAGE:
-    test [FLAGS] [OPTIONS]
+    test [FLAGS] [OPTIONS] [DUMMY]
 
 FLAGS:
     -F, --flag2      some other flag
@@ -25,9 +25,10 @@ fn hidden_args() {
     let app = App::new("test")
         .author("Kevin K.")
         .about("tests stuff")
-        .version("1.3")
+        .version("1.4")
         .args(&[Arg::from_usage("-f, --flag 'some flag'").hidden(true),
                     Arg::from_usage("-F, --flag2 'some other flag'"),
-                    Arg::from_usage("--option [opt] 'some option'")]);
+                    Arg::from_usage("--option [opt] 'some option'"),
+                    Arg::with_name("DUMMY").required(false).hidden(true)]);
     assert!(test::compare_output(app, "test --help", HIDDEN_ARGS, false));
 }


### PR DESCRIPTION
Also no need to check for Hidden inside for that already is filtered
on !Hidden.

Closes #882