### PR TITLE
Allow customizing the --version and --help messages

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1467,6 +1467,8 @@ impl<'a> From<&'a Yaml> for App<'a, 'a> {
         yaml_str!(a, yaml, help);
         yaml_str!(a, yaml, help_short);
         yaml_str!(a, yaml, version_short);
+        yaml_str!(a, yaml, help_message);
+        yaml_str!(a, yaml, version_message);
         yaml_str!(a, yaml, alias);
         yaml_str!(a, yaml, visible_alias);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -389,6 +389,44 @@ impl<'a, 'b> App<'a, 'b> {
         self
     }
 
+    /// Sets the help text for the auto-generated `help` argument.
+    ///
+    /// By default `clap` sets this to `"Prints help information"`, but if you're using a
+    /// different convention for your help messages and would prefer a different phrasing you can
+    /// override it.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .help_message("Print help information") // Perhaps you want imperative help messages
+    ///
+    /// # ;
+    /// ```
+    pub fn help_message<S: Into<&'a str>>(mut self, s: S) -> Self {
+        self.p.help_message(s.into());
+        self
+    }
+
+    /// Sets the help text for the auto-generated `version` argument.
+    ///
+    /// By default `clap` sets this to `"Prints version information"`, but if you're using a
+    /// different convention for your help messages and would prefer a different phrasing then you
+    /// can change it.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .version_message("Print version information") // Perhaps you want imperative help messages
+    /// # ;
+    /// ```
+    pub fn version_message<S: Into<&'a str>>(mut self, s: S) -> Self {
+        self.p.version_message(s.into());
+        self
+    }
+
     /// Sets the help template to be used, overriding the default format.
     ///
     /// Tags arg given inside curly brackets.

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -54,6 +54,8 @@ pub struct Parser<'a, 'b>
     overrides: Vec<&'b str>,
     help_short: Option<char>,
     version_short: Option<char>,
+    help_message: Option<&'a str>,
+    version_message: Option<&'a str>,
 }
 
 impl<'a, 'b> Parser<'a, 'b>
@@ -77,6 +79,14 @@ impl<'a, 'b> Parser<'a, 'b>
             .nth(0)
             .unwrap_or('V');
         self.version_short = Some(c);
+    }
+
+    pub fn help_message(&mut self, s: &'a str) {
+        self.help_message = Some(s);
+    }
+
+    pub fn version_message(&mut self, s: &'a str) {
+        self.version_message = Some(s);
     }
 
     pub fn gen_completions_to<W: Write>(&mut self, for_shell: Shell, buf: &mut W) {
@@ -1251,7 +1261,7 @@ impl<'a, 'b> Parser<'a, 'b>
             let arg = FlagBuilder {
                 b: Base {
                     name: "hclap_help",
-                    help: Some("Prints help information"),
+                    help: Some(self.help_message.unwrap_or("Prints help information")),
                     ..Default::default()
                 },
                 s: Switched {
@@ -1271,7 +1281,7 @@ impl<'a, 'b> Parser<'a, 'b>
             let arg = FlagBuilder {
                 b: Base {
                     name: "vclap_version",
-                    help: Some("Prints version information"),
+                    help: Some(self.version_message.unwrap_or("Prints version information")),
                     ..Default::default()
                 },
                 s: Switched {

--- a/tests/app.yml
+++ b/tests/app.yml
@@ -4,6 +4,7 @@ about: tests clap library
 author: Kevin K. <kbknapp@gmail.com>
 settings:
     - ArgRequiredElseHelp
+help_message: prints help with a nonstandard description
 args:
     - opt:
         short: o

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -225,6 +225,17 @@ FLAGS:
             Prints version
             information";
 
+static CUSTOM_VERSION_AND_HELP: &'static str = "customize 0.1
+Nobody <odysseus@example.com>
+You can customize the version and help text
+
+USAGE:
+    customize
+
+FLAGS:
+    -H, --help       Print help information
+    -v, --version    Print version information";
+
 #[test]
 fn help_short() {
     let m = App::new("test")
@@ -528,4 +539,17 @@ fn issue_777_wrap_all_things() {
         .about("Show how the about text is not wrapped")
         .set_term_width(35);
     assert!(test::compare_output(app, "ctest --help", ISSUE_777, false));
+}
+
+#[test]
+fn customize_version_and_help() {
+    let app = App::new("customize")
+        .version("0.1")
+        .author("Nobody <odysseus@example.com>")
+        .about("You can customize the version and help text")
+        .help_short("H")
+        .help_message("Print help information")
+        .version_short("v")
+        .version_message("Print version information");
+    assert!(test::compare_output(app, "customize --help", CUSTOM_VERSION_AND_HELP, false));
 }

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -10,3 +10,17 @@ fn create_app_from_yaml() {
     let yml = load_yaml!("app.yml");
     App::from_yaml(yml);
 }
+
+#[test]
+fn help_message() {
+    let yml = load_yaml!("app.yml");
+    let mut app = App::from_yaml(yml);
+    // Generate the full help message!
+    let _ = app.get_matches_from_safe_borrow(Vec::<String>::new());
+
+    let mut help_buffer = Vec::new();
+    app.write_help(&mut help_buffer).unwrap();
+    let help_string = String::from_utf8(help_buffer).unwrap();
+    assert!(help_string.contains(
+        "-h, --help             prints help with a nonstandard description\n"));
+}


### PR DESCRIPTION
Fixes #889 

This currently doesn't support customizing them from YAML, so it still needs some work.