### PR TITLE
imp: add fish subcommand help support

### DIFF
--- a/src/completions/fish.rs
+++ b/src/completions/fish.rs
@@ -95,6 +95,9 @@ fn gen_fish_inner(root_command: &str, comp_gen: &FishGen, parent_cmds: &str, buf
         let mut template = basic_template.clone();
         template.push_str(" -f");
         template.push_str(format!(" -a \"{}\"", &subcommand.p.meta.name).as_str());
+        if let Some(data) = subcommand.p.meta.about {
+            template.push_str(format!(" -d \"{}\"", &data).as_str())
+        }
         buffer.push_str(template.as_str());
         buffer.push_str("\n");
     }

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -169,8 +169,8 @@ end
 
 complete -c myapp -n "__fish_using_command myapp" -s h -l help -d "Prints help information"
 complete -c myapp -n "__fish_using_command myapp" -s V -l version -d "Prints version information"
-complete -c myapp -n "__fish_using_command myapp" -f -a "test"
-complete -c myapp -n "__fish_using_command myapp" -f -a "help"
+complete -c myapp -n "__fish_using_command myapp" -f -a "test" -d "tests things"
+complete -c myapp -n "__fish_using_command myapp" -f -a "help" -d "Prints this message or the help of the given subcommand(s)"
 complete -c myapp -n "__fish_using_command myapp test" -l case -d "the case to test"
 complete -c myapp -n "__fish_using_command myapp test" -s h -l help -d "Prints help information"
 complete -c myapp -n "__fish_using_command myapp test" -s V -l version -d "Prints version information"
@@ -475,9 +475,9 @@ end
 
 complete -c my_app -n "__fish_using_command my_app" -s h -l help -d "Prints help information"
 complete -c my_app -n "__fish_using_command my_app" -s V -l version -d "Prints version information"
-complete -c my_app -n "__fish_using_command my_app" -f -a "test"
-complete -c my_app -n "__fish_using_command my_app" -f -a "some_cmd"
-complete -c my_app -n "__fish_using_command my_app" -f -a "help"
+complete -c my_app -n "__fish_using_command my_app" -f -a "test" -d "tests things"
+complete -c my_app -n "__fish_using_command my_app" -f -a "some_cmd" -d "tests other things"
+complete -c my_app -n "__fish_using_command my_app" -f -a "help" -d "Prints this message or the help of the given subcommand(s)"
 complete -c my_app -n "__fish_using_command my_app test" -l case -d "the case to test"
 complete -c my_app -n "__fish_using_command my_app test" -s h -l help -d "Prints help information"
 complete -c my_app -n "__fish_using_command my_app test" -s V -l version -d "Prints version information"


### PR DESCRIPTION
Adds the `-d help_string` parameter to fish completion is present.

Example output:
```
complete -c mm3d -n "__fish_using_command mm3d" -f -a "Ann" -d "matches points [...]"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/905)
<!-- Reviewable:end -->
