### PR TITLE
Add Arg::hide_default_value()

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -498,14 +498,16 @@ impl<'a> Help<'a> {
     fn spec_vals(&self, a: &ArgWithDisplay) -> String {
         debugln!("Help::spec_vals: a={}", a);
         let mut spec_vals = vec![];
-        if let Some(pv) = a.default_val() {
-            debugln!("Help::spec_vals: Found default value...[{:?}]", pv);
-            spec_vals.push(format!(" [default: {}]",
-                                   if self.color {
-                                       self.cizer.good(pv.to_string_lossy())
-                                   } else {
-                                       Format::None(pv.to_string_lossy())
-                                   }));
+        if !a.is_set(ArgSettings::HideDefaultValue) {
+            if let Some(pv) = a.default_val() {
+                debugln!("Help::spec_vals: Found default value...[{:?}]", pv);
+                spec_vals.push(format!(" [default: {}]",
+                                       if self.color {
+                                           self.cizer.good(pv.to_string_lossy())
+                                       } else {
+                                           Format::None(pv.to_string_lossy())
+                                       }));
+            }
         }
         if let Some(ref aliases) = a.aliases() {
             debugln!("Help::spec_vals: Found aliases...{:?}", aliases);

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -1707,6 +1707,40 @@ impl<'a, 'b> Arg<'a, 'b> {
         }
     }
 
+    /// Specifies if the default value of an argument should be displayed in the help text or
+    /// not. Defaults to `false` (i.e. show default value)
+    ///
+    /// This is useful when default behavior of an arg is explained elsewhere in the help text.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::with_name("config")
+    ///     .hide_default_value(true)
+    /// # ;
+    /// ```
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("connect")
+    ///     .arg(Arg::with_name("host")
+    ///         .long("host")
+    ///         .default_value("localhost")
+    ///         .hide_default_value(true));
+    ///
+    /// ```
+    ///
+    /// If we were to run the above program with `--help` the `[default: localhost]` portion of
+    /// the help text would be omitted.
+    pub fn hide_default_value(self, hide: bool) -> Self {
+        if hide {
+            self.set(ArgSettings::HideDefaultValue)
+        } else {
+            self.unset(ArgSettings::HideDefaultValue)
+        }
+    }
+
     /// Specifies the index of a positional argument **starting at** 1.
     ///
     /// **NOTE:** The index refers to position according to **other positional argument**. It does

--- a/src/args/settings.rs
+++ b/src/args/settings.rs
@@ -4,21 +4,22 @@ use std::str::FromStr;
 
 bitflags! {
     flags Flags: u16 {
-        const REQUIRED       = 1 << 0,
-        const MULTIPLE       = 1 << 1,
-        const EMPTY_VALS     = 1 << 2,
-        const GLOBAL         = 1 << 3,
-        const HIDDEN         = 1 << 4,
-        const TAKES_VAL      = 1 << 5,
-        const USE_DELIM      = 1 << 6,
-        const NEXT_LINE_HELP = 1 << 7,
-        const R_UNLESS_ALL   = 1 << 8,
-        const REQ_DELIM      = 1 << 9,
-        const DELIM_NOT_SET  = 1 << 10,
-        const HIDE_POS_VALS  = 1 << 11,
-        const ALLOW_TAC_VALS = 1 << 12,
-        const REQUIRE_EQUALS = 1 << 13,
-        const LAST           = 1 << 14,
+        const REQUIRED         = 1 << 0,
+        const MULTIPLE         = 1 << 1,
+        const EMPTY_VALS       = 1 << 2,
+        const GLOBAL           = 1 << 3,
+        const HIDDEN           = 1 << 4,
+        const TAKES_VAL        = 1 << 5,
+        const USE_DELIM        = 1 << 6,
+        const NEXT_LINE_HELP   = 1 << 7,
+        const R_UNLESS_ALL     = 1 << 8,
+        const REQ_DELIM        = 1 << 9,
+        const DELIM_NOT_SET    = 1 << 10,
+        const HIDE_POS_VALS    = 1 << 11,
+        const ALLOW_TAC_VALS   = 1 << 12,
+        const REQUIRE_EQUALS   = 1 << 13,
+        const LAST             = 1 << 14,
+        const HIDE_DEFAULT_VAL = 1 << 15,
     }
 }
 
@@ -44,7 +45,8 @@ impl ArgFlags {
         HidePossibleValues => HIDE_POS_VALS,
         AllowLeadingHyphen => ALLOW_TAC_VALS,
         RequireEquals => REQUIRE_EQUALS,
-        Last => LAST
+        Last => LAST,
+        HideDefaultValue => HIDE_DEFAULT_VAL
     }
 }
 
@@ -87,6 +89,8 @@ pub enum ArgSettings {
     /// Specifies that the arg is the last positional argument and may be accessed early via `--`
     /// syntax
     Last,
+    /// Hides the default value from the help string
+    HideDefaultValue,
     #[doc(hidden)]
     RequiredUnlessAll,
     #[doc(hidden)]
@@ -112,6 +116,7 @@ impl FromStr for ArgSettings {
             "allowleadinghyphen" => Ok(ArgSettings::AllowLeadingHyphen),
             "requireequals" => Ok(ArgSettings::RequireEquals),
             "last" => Ok(ArgSettings::Last),
+            "hidedefaultvalue" => Ok(ArgSettings::HideDefaultValue),
             _ => Err("unknown ArgSetting, cannot convert from str".to_owned()),
         }
     }
@@ -153,6 +158,8 @@ mod test {
                    ArgSettings::RequireEquals);
         assert_eq!("last".parse::<ArgSettings>().unwrap(),
                    ArgSettings::Last);
+        assert_eq!("hidedefaultvalue".parse::<ArgSettings>().unwrap(),
+                   ArgSettings::HideDefaultValue);
         assert!("hahahaha".parse::<ArgSettings>().is_err());
     }
 }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -356,6 +356,18 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test    some";
 
+static HIDE_DEFAULT_VAL: &'static str = "default 0.1
+
+USAGE:
+    default [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --arg <argument>    Pass an argument to the program. [default: default-argument]";
+
 #[test]
 fn help_short() {
     let m = App::new("test")
@@ -750,4 +762,27 @@ fn last_arg_mult_usage_with_sc() {
             .arg(Arg::with_name("ARGS").multiple(true).last(true).help("some"))
             .subcommand(SubCommand::with_name("test").about("some"));
     assert!(test::compare_output(app, "last --help", LAST_ARG_SC, false));
+}
+
+
+#[test]
+fn hidden_default_val() {
+    let app1 = App::new("default")
+        .version("0.1")
+        .set_term_width(120)
+        .arg(Arg::with_name("argument")
+             .help("Pass an argument to the program. [default: default-argument]")
+             .long("arg")
+             .default_value("default-argument")
+             .hide_default_value(true));
+    assert!(test::compare_output(app1, "default --help", HIDE_DEFAULT_VAL, false));
+
+    let app2 = App::new("default")
+        .version("0.1")
+        .set_term_width(120)
+        .arg(Arg::with_name("argument")
+             .help("Pass an argument to the program.")
+             .long("arg")
+             .default_value("default-argument"));
+    assert!(test::compare_output(app2, "default --help", HIDE_DEFAULT_VAL, false));
 }


### PR DESCRIPTION
Adds a new method, `Arg::hide_default_value()`, to hide the default argument from the help string.
Fixes #902.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/913)
<!-- Reviewable:end -->
