### PR TITLE
Bump vec_map dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ A simple to use, efficient, and full featured  Command Line Argument Parser
 
 [dependencies]
 bitflags              = "0.8.0"
-vec_map               = "0.7.0"
+vec_map               = "0.8.0"
 unicode-width         = "0.1.4"
 unicode-segmentation  = "1.0.1"
 strsim    = { version = "0.6.0",  optional = true }


### PR DESCRIPTION
`vec_map` used to have very slow implementations of `len()` and `is_empty()`. Now that contain-rs/vec-map#33 has landed, these are constant-time operations, [certain](https://github.com/kbknapp/clap-rs/blob/7b08a0a5832c4900eb84bc5a9abfb258c1636f2e/src/args/arg_builder/valued.rs#L57) [clap](https://github.com/kbknapp/clap-rs/blob/54c16836dea4651806a2cfad53146a83fa3abf21/src/args/arg_builder/positional.rs#L107) [operations](https://github.com/kbknapp/clap-rs/blob/7b08a0a5832c4900eb84bc5a9abfb258c1636f2e/src/args/arg_builder/valued.rs#L46) [should](https://github.com/kbknapp/clap-rs/blob/54c16836dea4651806a2cfad53146a83fa3abf21/src/args/arg_builder/positional.rs#L78) [be](https://github.com/kbknapp/clap-rs/search?utf8=✓&q=VecMap&type=) a fair bit faster. While it's true clap rarely has to deal with many arguments, this might still help speed some things up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/958)
<!-- Reviewable:end -->
