### PR TITLE
cargo: restrict unicode-segmentation to ~1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ A simple to use, efficient, and full featured  Command Line Argument Parser
 bitflags              = "0.8.0"
 vec_map               = "0.8"
 unicode-width         = "0.1.4"
-unicode-segmentation  = "1.0.1"
+unicode-segmentation  = "~1.1.0" # 1.2.0 requires Rust 1.13.0
 strsim    = { version = "0.6.0",  optional = true }
 ansi_term = { version = "0.9.0",  optional = true }
 term_size = { version = "0.3.0",  optional = true }


### PR DESCRIPTION
Version 1.2.0 of unicode-segmentation adds code that use the "?"
operator, which in turn requires Rust 1.13.0. However, clap currently
still works with Rust 1.11.0 and this caused build failures:

  https://travis-ci.org/kbknapp/clap-rs/jobs/235010822

The changes since 1.1.0 seem to be related cursors/iterators and I
think clap can work fine without them.

This was found as part of #845. See also https://github.com/unicode-rs/unicode-segmentation/issues/26.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/967)
<!-- Reviewable:end -->
