### PR TITLE
Small cleanups and refactoring in help generation

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -395,8 +395,7 @@ impl<'a> Help<'a> {
             // Determine how many newlines we need to insert
             debugln!("Help::write_before_after_help: Usable space: {}",
                      self.term_w);
-            help = help.replace("{n}", "\n");
-            wrap_help(&mut help, self.term_w);
+            help = wrap_help(&help.replace("{n}", "\n"), self.term_w);
         } else {
             sdebugln!("No");
         }
@@ -437,8 +436,7 @@ impl<'a> Help<'a> {
             // Determine how many newlines we need to insert
             let avail_chars = self.term_w - spcs;
             debugln!("Help::help: Usable space...{}", avail_chars);
-            help = help.replace("{n}", "\n");
-            wrap_help(&mut help, avail_chars);
+            help = wrap_help(&help.replace("{n}", "\n"), avail_chars);
         } else {
             sdebugln!("No");
         }
@@ -616,8 +614,7 @@ impl<'a> Help<'a> {
             () => {{
                 let mut name = parser.meta.name.clone();
                 name = name.replace("{n}", "\n");
-                wrap_help(&mut name, self.term_w);
-                try!(color!(self, &*name, good));
+                try!(color!(self, wrap_help(&name, self.term_w), good));
             }};
         }
         if let Some(bn) = parser.meta.bin_name.as_ref() {
@@ -645,8 +642,8 @@ impl<'a> Help<'a> {
             ($thing:expr) => {{
                 let mut owned_thing = $thing.to_owned();
                 owned_thing = owned_thing.replace("{n}", "\n");
-                wrap_help(&mut owned_thing, self.term_w);
-                try!(write!(self.writer, "{}\n", &*owned_thing))
+                try!(write!(self.writer, "{}\n",
+                            wrap_help(&owned_thing, self.term_w)))
             }};
         }
         // Print the version
@@ -907,12 +904,12 @@ impl<'a> Help<'a> {
     }
 }
 
-fn wrap_help(help: &mut String, avail_chars: usize) {
+fn wrap_help(help: &str, avail_chars: usize) -> String {
     let wrapper = textwrap::Wrapper::new(avail_chars).break_words(false);
-    *help = help.lines()
+    help.lines()
         .map(|line| wrapper.fill(line))
         .collect::<Vec<String>>()
-        .join("\n");
+        .join("\n")
 }
 
 #[cfg(test)]
@@ -921,8 +918,7 @@ mod test {
 
     #[test]
     fn wrap_help_last_word() {
-        let mut help = String::from("foo bar baz");
-        wrap_help(&mut help, 5);
-        assert_eq!(help, "foo\nbar\nbaz");
+        let help = String::from("foo bar baz");
+        assert_eq!(wrap_help(&help, 5), "foo\nbar\nbaz");
     }
 }

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -413,15 +413,11 @@ impl<'a> Help<'a> {
         } else {
             sdebugln!("No");
         }
-        if help.contains('\n') {
-            if let Some(part) = help.lines().next() {
-                try!(write!(self.writer, "{}", part));
-            }
-            for part in help.lines().skip(1) {
-                try!(write!(self.writer, "\n{}", part));
-            }
-        } else {
-            try!(write!(self.writer, "{}", help));
+        if let Some(part) = help.lines().next() {
+            try!(write!(self.writer, "{}", part));
+        }
+        for part in help.lines().skip(1) {
+            try!(write!(self.writer, "\n{}", part));
         }
         Ok(())
     }
@@ -465,26 +461,22 @@ impl<'a> Help<'a> {
         } else {
             sdebugln!("No");
         }
-        if help.contains('\n') {
-            if let Some(part) = help.lines().next() {
-                try!(write!(self.writer, "{}", part));
-            }
-            for part in help.lines().skip(1) {
-                try!(write!(self.writer, "\n"));
-                if nlh || self.force_next_line {
-                    try!(write!(self.writer, "{}{}{}", TAB, TAB, TAB));
-                } else if arg.has_switch() {
-                    write_nspaces!(self.writer, self.longest + 12);
-                } else {
-                    write_nspaces!(self.writer, self.longest + 8);
-                }
-                try!(write!(self.writer, "{}", part));
-            }
-        } else if nlh || self.force_next_line {
-            try!(write!(self.writer, "{}", help));
+        if let Some(part) = help.lines().next() {
+            try!(write!(self.writer, "{}", part));
+        }
+        for part in help.lines().skip(1) {
             try!(write!(self.writer, "\n"));
-        } else {
-            try!(write!(self.writer, "{}", help));
+            if nlh || self.force_next_line {
+                try!(write!(self.writer, "{}{}{}", TAB, TAB, TAB));
+            } else if arg.has_switch() {
+                write_nspaces!(self.writer, self.longest + 12);
+            } else {
+                write_nspaces!(self.writer, self.longest + 8);
+            }
+            try!(write!(self.writer, "{}", part));
+        }
+        if !help.contains('\n') && (nlh || self.force_next_line) {
+            try!(write!(self.writer, "\n"));
         }
         Ok(())
     }

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -413,12 +413,7 @@ impl<'a> Help<'a> {
         } else {
             sdebugln!("No");
         }
-        if let Some(part) = help.lines().next() {
-            try!(write!(self.writer, "{}", part));
-        }
-        for part in help.lines().skip(1) {
-            try!(write!(self.writer, "\n{}", part));
-        }
+        try!(write!(self.writer, "{}", help));
         Ok(())
     }
 

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -25,18 +25,6 @@ mod term_size {
     pub fn dimensions() -> Option<(usize, usize)> { None }
 }
 
-macro_rules! find_longest {
-    ($help:expr) => {{
-        let mut lw = 0;
-        for l in $help.split(' ').map(|s| str_width(s)) {
-            if l > lw {
-                lw = l;
-            }
-        }
-        lw
-    }};
-}
-
 fn str_width(s: &str) -> usize { UnicodeWidthStr::width(s) }
 
 const TAB: &'static str = "    ";
@@ -407,9 +395,8 @@ impl<'a> Help<'a> {
             // Determine how many newlines we need to insert
             debugln!("Help::write_before_after_help: Usable space: {}",
                      self.term_w);
-            let longest_w = find_longest!(help);
             help = help.replace("{n}", "\n");
-            wrap_help(&mut help, longest_w, self.term_w);
+            wrap_help(&mut help, self.term_w);
         } else {
             sdebugln!("No");
         }
@@ -450,9 +437,8 @@ impl<'a> Help<'a> {
             // Determine how many newlines we need to insert
             let avail_chars = self.term_w - spcs;
             debugln!("Help::help: Usable space...{}", avail_chars);
-            let longest_w = find_longest!(help);
             help = help.replace("{n}", "\n");
-            wrap_help(&mut help, longest_w, avail_chars);
+            wrap_help(&mut help, avail_chars);
         } else {
             sdebugln!("No");
         }
@@ -629,9 +615,8 @@ impl<'a> Help<'a> {
         macro_rules! write_name {
             () => {{
                 let mut name = parser.meta.name.clone();
-                let longest_w = find_longest!(name);            
                 name = name.replace("{n}", "\n");
-                wrap_help(&mut name, longest_w, self.term_w);
+                wrap_help(&mut name, self.term_w);
                 try!(color!(self, &*name, good));
             }};
         }
@@ -659,9 +644,8 @@ impl<'a> Help<'a> {
         macro_rules! write_thing {
             ($thing:expr) => {{
                 let mut owned_thing = $thing.to_owned();
-                let longest_w = find_longest!(owned_thing);            
                 owned_thing = owned_thing.replace("{n}", "\n");
-                wrap_help(&mut owned_thing, longest_w, self.term_w);
+                wrap_help(&mut owned_thing, self.term_w);
                 try!(write!(self.writer, "{}\n", &*owned_thing))
             }};
         }
@@ -923,15 +907,12 @@ impl<'a> Help<'a> {
     }
 }
 
-fn wrap_help(help: &mut String, longest_w: usize, avail_chars: usize) {
-    // Keep previous behavior of not wrapping at all if one of the
-    // words would overflow the line.
-    if longest_w < avail_chars {
-        *help = help.lines()
-            .map(|line| textwrap::fill(line, avail_chars))
-            .collect::<Vec<String>>()
-            .join("\n");
-    }
+fn wrap_help(help: &mut String, avail_chars: usize) {
+    let wrapper = textwrap::Wrapper::new(avail_chars).break_words(false);
+    *help = help.lines()
+        .map(|line| wrapper.fill(line))
+        .collect::<Vec<String>>()
+        .join("\n");
 }
 
 #[cfg(test)]
@@ -941,7 +922,7 @@ mod test {
     #[test]
     fn wrap_help_last_word() {
         let mut help = String::from("foo bar baz");
-        wrap_help(&mut help, 3, 5);
+        wrap_help(&mut help, 5);
         assert_eq!(help, "foo\nbar\nbaz");
     }
 }

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -392,7 +392,7 @@ impl<'a> Help<'a> {
 
     fn write_before_after_help(&mut self, h: &str) -> io::Result<()> {
         debugln!("Help::write_before_after_help;");
-        let mut help = String::new();
+        let mut help = String::from(h);
         // determine if our help fits or needs to wrap
         debugln!("Help::write_before_after_help: Term width...{}",
                  self.term_w);
@@ -401,7 +401,6 @@ impl<'a> Help<'a> {
         debug!("Help::write_before_after_help: Too long...");
         if too_long || h.contains("{n}") {
             sdebugln!("Yes");
-            help.push_str(h);
             debugln!("Help::write_before_after_help: help: {}", help);
             debugln!("Help::write_before_after_help: help width: {}",
                      str_width(&*help));
@@ -414,12 +413,6 @@ impl<'a> Help<'a> {
         } else {
             sdebugln!("No");
         }
-        let help = if !help.is_empty() {
-            &*help
-        } else {
-            help.push_str(h);
-            &*help
-        };
         if help.contains('\n') {
             if let Some(part) = help.lines().next() {
                 try!(write!(self.writer, "{}", part));
@@ -436,12 +429,12 @@ impl<'a> Help<'a> {
     /// Writes argument's help to the wrapped stream.
     fn help<'b, 'c>(&mut self, arg: &ArgWithDisplay<'b, 'c>, spec_vals: &str) -> io::Result<()> {
         debugln!("Help::help;");
-        let mut help = String::new();
         let h = if self.use_long {
             arg.long_help().unwrap_or(arg.help().unwrap_or(""))
         } else {
             arg.help().unwrap_or(arg.long_help().unwrap_or(""))
         };
+        let mut help = String::from(h) + spec_vals;
         let nlh = self.next_line_help || arg.is_set(ArgSettings::NextLineHelp) || self.use_long;
         debugln!("Help::help: Next Line...{:?}", nlh);
 
@@ -461,8 +454,6 @@ impl<'a> Help<'a> {
         debug!("Help::help: Too long...");
         if too_long && spcs <= self.term_w || h.contains("{n}") {
             sdebugln!("Yes");
-            help.push_str(h);
-            help.push_str(&*spec_vals);
             debugln!("Help::help: help...{}", help);
             debugln!("Help::help: help width...{}", str_width(&*help));
             // Determine how many newlines we need to insert
@@ -474,15 +465,6 @@ impl<'a> Help<'a> {
         } else {
             sdebugln!("No");
         }
-        let help = if !help.is_empty() {
-            &*help
-        } else if spec_vals.is_empty() {
-            h
-        } else {
-            help.push_str(h);
-            help.push_str(&*spec_vals);
-            &*help
-        };
         if help.contains('\n') {
             if let Some(part) = help.lines().next() {
                 try!(write!(self.writer, "{}", part));


### PR DESCRIPTION
This PR aims to simplify the help generation code a little.

It also lets `textwrap` handle long words, i.e., words longer than the available line width. Before, no wrapping what so ever was done if it was detected that the longest word could not fit into the line. Now, the text is still being wrapped -- the long word will simply be put on a line by itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/974)
<!-- Reviewable:end -->
