### PR TITLE
Suggest to use flag after a sub-command 

### DIFF
--- a/clap-test.rs
+++ b/clap-test.rs
@@ -70,6 +70,7 @@ mod test {
                                     .version("0.1")
                                     .author("Kevin K. <kbknapp@gmail.com>")
                                     .arg_from_usage("-o --option [scoption]... 'tests options'")
+                                    .arg_from_usage("-s --subcmdarg [subcmdarg] 'tests other args'")
                                     .arg_from_usage("[scpositional] 'tests positionals'"))
     }
 }

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1665,7 +1665,7 @@ impl<'a, 'b> Parser<'a, 'b>
 
         // Didn't match a flag or option
         let suffix =
-            suggestions::did_you_mean_arg_suffix(arg, longs!(self), &self.subcommands);
+            suggestions::did_you_mean_flag_suffix(arg, longs!(self), &self.subcommands);
 
         // Add the arg to the matches to build a proper usage string
         if let Some(name) = suffix.1 {

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1662,11 +1662,10 @@ impl<'a, 'b> Parser<'a, 'b>
     }
 
     fn did_you_mean_error(&self, arg: &str, matcher: &mut ArgMatcher<'a>) -> ClapResult<()> {
-        // Didn't match a flag or option...maybe it was a typo and close to one
+
+        // Didn't match a flag or option
         let suffix =
-            suggestions::did_you_mean_suffix(arg,
-                                             longs!(self),
-                                             suggestions::DidYouMeanMessageStyle::LongFlag);
+            suggestions::did_you_mean_arg_suffix(arg, longs!(self), &self.subcommands);
 
         // Add the arg to the matches to build a proper usage string
         if let Some(name) = suffix.1 {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -483,9 +483,9 @@ impl Error {
             when: color,
         });
         let suffix =
-            suggestions::did_you_mean_suffix(bad_val.as_ref(),
-                                             good_vals.iter(),
-                                             suggestions::DidYouMeanMessageStyle::EnumValue);
+            suggestions::did_you_mean_value_suffix(
+                bad_val.as_ref(),
+                good_vals.iter());
 
         let mut sorted = vec![];
         for v in good_vals {

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -103,15 +103,13 @@ mod test {
     fn suffix_long() {
         let p_vals = ["test", "possible", "values"];
         let suffix = "\n\tDid you mean \'--test\'?";
-        assert_eq!(did_you_mean_suffix("tst", p_vals.iter(), DidYouMeanMessageStyle::LongFlag),
-                   (suffix, Some("test")));
+        assert_eq!(did_you_mean_flag_suffix("tst", p_vals.iter(), []), (suffix, Some("test")));
     }
 
     #[test]
     fn suffix_enum() {
         let p_vals = ["test", "possible", "values"];
         let suffix = "\n\tDid you mean \'test\'?";
-        assert_eq!(did_you_mean_suffix("tst", p_vals.iter(), DidYouMeanMessageStyle::EnumValue),
-                   (suffix, Some("test")));
+        assert_eq!(did_you_mean_value_suffix("tst", p_vals.iter()), (suffix, Some("test")));
     }
 }

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -1,3 +1,4 @@
+use app::App;
 // Third Party
 #[cfg(feature = "suggestions")]
 use strsim;
@@ -40,40 +41,46 @@ pub fn did_you_mean<'a, T: ?Sized, I>(_: &str, _: I) -> Option<&'a str>
 
 /// Returns a suffix that can be empty, or is the standard 'did you mean' phrase
 #[cfg_attr(feature = "lints", allow(needless_lifetimes))]
-pub fn did_you_mean_suffix<'z, T, I>(arg: &str,
-                                     values: I,
-                                     style: DidYouMeanMessageStyle)
+pub fn did_you_mean_flag_suffix<'z, T, I>(arg: &str, longs: I, subcommands: &'z [App])
                                      -> (String, Option<&'z str>)
+    where T: AsRef<str> + 'z,
+          I: IntoIterator<Item = &'z T>
+{
+    match did_you_mean(arg, longs) {
+        Some(candidate) => {
+            let suffix = format!("\n\tDid you mean {}{}?", Format::Good("--"), Format::Good(candidate));
+            return (suffix, Some(candidate))
+        }
+        None => {
+            for subcommand in subcommands {
+                let opts = subcommand.p.flags.iter().filter_map(|f| f.s.long).chain(
+                    subcommand.p.opts.iter().filter_map(|o| o.s.long));
+
+                if let Some(candidate) = did_you_mean(arg, opts) {
+                    let suffix = format!(
+                        "\n\tDid you mean to put '--{}' after the subcommand '{}'?",
+                        Format::Good(arg),
+                        Format::Good(candidate));
+                    return (suffix, Some(candidate));
+                }
+            }
+        }
+    }
+    return (String::new(), None)
+}
+
+/// Returns a suffix that can be empty, or is the standard 'did you mean' phrase
+pub fn did_you_mean_value_suffix<'z, T, I>(arg: &str, values: I) -> (String, Option<&'z str>)
     where T: AsRef<str> + 'z,
           I: IntoIterator<Item = &'z T>
 {
     match did_you_mean(arg, values) {
         Some(candidate) => {
-            let mut suffix = "\n\tDid you mean ".to_owned();
-            match style {
-                DidYouMeanMessageStyle::LongFlag => {
-                    suffix.push_str(&Format::Good("--").to_string())
-                }
-                DidYouMeanMessageStyle::EnumValue => suffix.push('\''),
-            }
-            suffix.push_str(&Format::Good(candidate).to_string()[..]);
-            if let DidYouMeanMessageStyle::EnumValue = style {
-                suffix.push('\'');
-            }
-            suffix.push_str("?");
+            let suffix = format!("\n\tDid you mean '{}'?", Format::Good(candidate));
             (suffix, Some(candidate))
         }
         None => (String::new(), None),
     }
-}
-
-/// A helper to determine message formatting
-#[derive(Copy, Clone, Debug)]
-pub enum DidYouMeanMessageStyle {
-    /// Suggested value is a long flag
-    LongFlag,
-    /// Suggested value is one of various possible values
-    EnumValue,
 }
 
 #[cfg(all(test, features = "suggestions"))]

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -118,7 +118,8 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -o, --option <scoption>...    tests options
+    -o, --option <scoption>...     tests options
+    -s, --subcmdarg <subcmdarg>    tests other args
 
 ARGS:
     <scpositional>    tests positionals";

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -42,6 +42,15 @@ USAGE:
 
 For more information try --help";
 
+#[cfg(feature = "suggestions")]
+static DYM2: &'static str = "error: Found argument '--subcmdarg' which wasn't expected, or isn't valid in this context
+\tDid you mean to put '--subcmdarg' after the subcommand 'subcmdarg'?
+
+USAGE:
+    clap-test [FLAGS] [OPTIONS] [ARGS] [SUBCOMMAND]
+
+For more information try --help";
+
 #[test]
 fn subcommand() {
     let m = App::new("test")
@@ -121,6 +130,7 @@ fn multiple_aliases() {
 #[cfg(feature="suggestions")]
 fn subcmd_did_you_mean_output() {
     assert!(test::compare_output(test::complex_app(), "clap-test subcm", DYM, true));
+    assert!(test::compare_output(test::complex_app(), "clap-test --subcmdarg foo", DYM2, true));
 }
 
 #[test]


### PR DESCRIPTION
Hi @kbknapp,

I saw that  https://github.com/kbknapp/clap-rs/issues/927 was mentored, so I'd like to give it a try.
Here is a first attempt. The message is simpler than what to suggest in the issue, because I could not find out how to print this part from `did_you_mean_flag_suffix`:

```
        myapp --foo bar
              ^^^^^

```

By the way, I splitted `did_you_mean_suffix` into `did_you_mean_flag_suffix` and `did_you_mean_value_suffix`, is that ok?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/980)
<!-- Reviewable:end -->
