### PR TITLE
impl Default for Values + OsValues for any lifetime.

### DIFF
--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -568,7 +568,7 @@ impl<'a> DoubleEndedIterator for Values<'a> {
 impl<'a> ExactSizeIterator for Values<'a> {}
 
 /// Creates an empty iterator.
-impl Default for Values<'static> {
+impl<'a> Default for Values<'a> {
     fn default() -> Self {
         static EMPTY: [OsString; 0] = [];
         // This is never called because the iterator is empty:
@@ -580,6 +580,13 @@ impl Default for Values<'static> {
 #[test]
 fn test_default_values() {
     let mut values: Values = Values::default();
+    assert_eq!(values.next(), None);
+}
+
+#[test]
+fn test_default_values_with_shorter_lifetime() {
+    let matches = ArgMatches::new();
+    let mut values = matches.values_of("").unwrap_or_default();
     assert_eq!(values.next(), None);
 }
 
@@ -622,7 +629,7 @@ impl<'a> DoubleEndedIterator for OsValues<'a> {
 }
 
 /// Creates an empty iterator.
-impl Default for OsValues<'static> {
+impl<'a> Default for OsValues<'a> {
     fn default() -> Self {
         static EMPTY: [OsString; 0] = [];
         // This is never called because the iterator is empty:
@@ -634,5 +641,12 @@ impl Default for OsValues<'static> {
 #[test]
 fn test_default_osvalues() {
     let mut values: OsValues = OsValues::default();
+    assert_eq!(values.next(), None);
+}
+
+#[test]
+fn test_default_osvalues_with_shorter_lifetime() {
+    let matches = ArgMatches::new();
+    let mut values = matches.values_of_os("").unwrap_or_default();
     assert_eq!(values.next(), None);
 }


### PR DESCRIPTION
`Values` and `OsValues` are apparently invariant, i.e. a `Values<'static>` cannot be assigned to a `Values<'a>`

This makes the `impl Default for Values<'static>` basically useless since most of the time these types are obtained from an `ArgMatches::values_of()` as a `Values<'a>`. In particular `matches.values_of().unwrap_or_default()` would fail:

```
error[E0597]: `matches` does not live long enough
   --> src/args/arg_matches.rs:650:22
    |
650 |     let mut values = matches.values_of_os("").unwrap_or_default();
    |                      ^^^^^^^ does not live long enough
651 |     assert_eq!(values.next(), None);
652 | }
    | - borrowed value only lives until here
    |
    = note: borrowed value must be valid for the static lifetime...
```

This PR implemented the Default trait for all lifetimes so that `matches.values_of().unwrap_or_default()` could work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/998)
<!-- Reviewable:end -->
