### PR TITLE
perf: update textwrap to version 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bitflags              = "0.9"
 vec_map               = "0.8"
 unicode-width         = "0.1.4"
 unicode-segmentation  = "~1.1.0" # 1.2.0 requires Rust 1.13.0
-textwrap              = "0.6.0"
+textwrap              = "0.7.0"
 strsim    = { version = "0.6.0",  optional = true }
 ansi_term = { version = "0.9.0",  optional = true }
 term_size = { version = "0.3.0",  optional = true }


### PR DESCRIPTION
This version of textwrap uses a new wrapping algorithm that allocates
fewer strings on the heap.

The 05_ripgrep benchmarks shows a performance improvement of 3-15%.
The build_help_long benchmark benefits the most since it uses longer
help texts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1009)
<!-- Reviewable:end -->
