### PR TITLE
Example for an external subcommand.

### DIFF
--- a/examples/23_external_subcommand.rs
+++ b/examples/23_external_subcommand.rs
@@ -1,0 +1,21 @@
+extern crate clap;
+
+use clap::{App, Arg, AppSettings};
+
+// ./app grep -i bash /etc/passwd
+// ./app -o foo -o bar grep -i bash /etc/passwd
+fn main() {
+    let matches = App::new("app")
+        .setting(AppSettings::AllowExternalSubcommands)
+        .arg(
+            Arg::with_name("option")
+                .short("o")
+                .required(false)
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1),
+        )
+        .get_matches();
+
+    println!("{:#?}", matches);
+}


### PR DESCRIPTION
Add an example for spawning an external subcommand with a multiply existing argument. This was pretty hard for me to find. 

Why is the subcommand not displayed in help? I get:

```
app [OPTIONS]
```
I'd expect
```
app [OPTIONS] [COMMAND]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1012)
<!-- Reviewable:end -->
