### PR TITLE
Make the Shell enum non-exhaustive

### DIFF
--- a/clap_completions/src/shell.rs
+++ b/clap_completions/src/shell.rs
@@ -14,6 +14,8 @@ pub enum Shell {
     Zsh,
     /// Generates a completion file for PowerShell
     PowerShell,
+    #[doc(hidden)]
+    __nonexhaustive_dont_match,
 }
 
 impl Shell {
@@ -43,6 +45,7 @@ impl fmt::Display for Shell {
             Shell::Fish => write!(f, "FISH"),
             Shell::Zsh => write!(f, "ZSH"),
             Shell::PowerShell => write!(f, "POWERSHELL"),
+            Shell::__nonexhaustive_dont_match => write!(f, "Shell::__nonexhaustive_dont_match (should NOT be used)"),
         }
     }
 }


### PR DESCRIPTION
There's also an `enum Shell` in `src/builders/App.rs`, but it's marked as "@TODO-v3-beta: Remove" so this PR doesn't change it.

This PR is against the `v3-master` branch, I'm not sure if I should be using `v3-dev`.

Edit: resolves #994

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1017)
<!-- Reviewable:end -->
