### PR TITLE
Fix documentation for loading yaml

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,7 @@
 //! extern crate clap;
 //! use clap::App;
 //! 
+//! #[cfg(feature = "yaml")]
 //! fn main() {
 //!     // The YAML file is found relative to the current file, similar to how modules are found
 //!     let yaml = load_yaml!("cli.yml");


### PR DESCRIPTION
I was trying to get YAML loading working and ended up having to find elsewhere that the `#[cfg(feature = "yaml")]` flag was needed. Updated the documentation to include said flag :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1025)
<!-- Reviewable:end -->
