### PR TITLE
fix: avoid panic generating default help msg if term width set to 0 due to issue in textwrap 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ appveyor = { repository = "kbknapp/clap-rs" }
 bitflags              = "0.9"
 vec_map               = "0.8"
 unicode-width         = "0.1.4"
-unicode-segmentation  = "1.2.0" 
-textwrap              = "0.7.0"
+unicode-segmentation  = "1.2.0"
+textwrap              = "0.8.0"
 strsim    = { version = "0.6.0",  optional = true }
 ansi_term = { version = "0.9.0",  optional = true }
 term_size = { version = "0.3.0",  optional = true }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -431,6 +431,15 @@ ARGS:
     <FIRST>...     First
     <SECOND>...    Second";
 
+static DEFAULT_HELP: &'static str = "ctest 
+
+USAGE:
+    ctest
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information";
+
 #[test]
 fn help_short() {
     let m = App::new("test")
@@ -590,6 +599,12 @@ fn no_wrap_help() {
         .set_term_width(0)
         .help(MULTI_SC_HELP);
     assert!(test::compare_output(app, "ctest --help", MULTI_SC_HELP, false));
+}
+
+#[test]
+fn no_wrap_default_help() {
+    let app = App::new("ctest").set_term_width(0);
+    assert!(test::compare_output(app, "ctest --help", DEFAULT_HELP, false));
 }
 
 #[test]


### PR DESCRIPTION
Generating a default help message where `set_term_width(0)` had been applied caused the app to panic due to [this line](https://github.com/mgeisler/textwrap/blob/0.7.0/src/lib.rs#L355) in textwrap 0.7.0.  In this case, `self.width` would be `usize::MAX` and the call would result in an 'attempt to divide by zero' or 'attempt to add with overflow' panic depending on the build type.

This issue no longer exists in textwrap 0.8.0 (hence I didn't file an issue there).  Tagging @mgeisler for info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1040)
<!-- Reviewable:end -->
