### PR TITLE
make vec_map optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ appveyor = { repository = "kbknapp/clap-rs" }
 
 [dependencies]
 bitflags              = "0.9"
-vec_map               = "0.8"
 unicode-width         = "0.1.4"
 textwrap              = "0.8.0"
 strsim    = { version = "0.6.0",  optional = true }
@@ -30,13 +29,14 @@ term_size = { version = "0.3.0",  optional = true }
 yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.131", optional = true }
 atty      = { version = "0.2.2",  optional = true }
+vec_map   = { version = "0.8", optional = true }
 
 [dev-dependencies]
 regex = "0.2"
 lazy_static = "0.2"
 
 [features]
-default     = ["suggestions", "color", "wrap_help"]
+default     = ["suggestions", "color", "wrap_help", "vec_map"]
 suggestions = ["strsim"]
 color       = ["ansi_term", "atty"]
 wrap_help   = ["term_size"]

--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ Then run `cargo build` or `cargo update && cargo build` for your project.
 * **"suggestions"**: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
 * **"color"**: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term`)
 * **"wrap_help"**: Wraps the help at the actual terminal width when available, instead of 120 characters. (builds dependency `term_size`)
+* **"vec_map"**: Use [`VecMap`](https://crates.io/crates/vec_map) internally instead of a [`BTreeMap`](https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html). This feature provides a _slight_ performance improvement. (builds dependency `vec_map`)
 
 To disable these, add this to your `Cargo.toml`:
 

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -12,13 +12,13 @@ use args::{AnyArg, ArgSettings, DispOrder};
 use errors::{Error, Result as ClapResult};
 use fmt::{Format, Colorizer, ColorizerOption};
 use app::usage;
+use map::VecMap;
 
 // Third Party
 use unicode_width::UnicodeWidthStr;
 #[cfg(feature = "wrap_help")]
 use term_size;
 use textwrap;
-use vec_map::VecMap;
 
 #[cfg(not(feature = "wrap_help"))]
 mod term_size {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,7 +18,6 @@ use std::rc::Rc;
 use std::result::Result as StdResult;
 
 // Third Party
-use vec_map::{self, VecMap};
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
 
@@ -29,6 +28,7 @@ use args::{AnyArg, Arg, ArgGroup, ArgMatcher, ArgMatches, ArgSettings};
 use errors::Result as ClapResult;
 pub use self::settings::AppSettings;
 use completions::Shell;
+use map::{self, VecMap};
 
 /// Used to create a representation of a command line program and all possible command line
 /// arguments. Application settings are set using the "builder pattern" with the
@@ -1793,7 +1793,7 @@ impl<'n, 'e> AnyArg<'n, 'e> for App<'n, 'e> {
     fn help(&self) -> Option<&'e str> { self.p.meta.about }
     fn long_help(&self) -> Option<&'e str> { self.p.meta.long_about }
     fn default_val(&self) -> Option<&'e OsStr> { None }
-    fn default_vals_ifs(&self) -> Option<vec_map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
+    fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         None
     }
     fn longest_filter(&self) -> bool { true }

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -9,9 +9,6 @@ use std::path::PathBuf;
 use std::slice::Iter;
 use std::iter::Peekable;
 
-// Third Party
-use vec_map::{self, VecMap};
-
 // Internal
 use INTERNAL_ERROR_MSG;
 use INVALID_UTF8;
@@ -32,6 +29,7 @@ use suggestions;
 use app::settings::AppSettings as AS;
 use app::validator::Validator;
 use app::usage;
+use map::{self, VecMap};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 #[doc(hidden)]
@@ -1795,7 +1793,7 @@ impl<'a, 'b> Parser<'a, 'b>
 
     pub fn opts(&self) -> Iter<OptBuilder<'a, 'b>> { self.opts.iter() }
 
-    pub fn positionals(&self) -> vec_map::Values<PosBuilder<'a, 'b>> { self.positionals.values() }
+    pub fn positionals(&self) -> map::Values<PosBuilder<'a, 'b>> { self.positionals.values() }
 
     pub fn subcommands(&self) -> Iter<App> { self.subcommands.iter() }
 

--- a/src/args/any_arg.rs
+++ b/src/args/any_arg.rs
@@ -3,11 +3,9 @@ use std::rc::Rc;
 use std::fmt as std_fmt;
 use std::ffi::{OsStr, OsString};
 
-// Third Party
-use vec_map::{self, VecMap};
-
 // Internal
 use args::settings::ArgSettings;
+use map::{self, VecMap};
 
 #[doc(hidden)]
 pub trait AnyArg<'n, 'e>: std_fmt::Display {
@@ -34,7 +32,7 @@ pub trait AnyArg<'n, 'e>: std_fmt::Display {
     fn help(&self) -> Option<&'e str>;
     fn long_help(&self) -> Option<&'e str>;
     fn default_val(&self) -> Option<&'e OsStr>;
-    fn default_vals_ifs(&self) -> Option<vec_map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>>;
+    fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>>;
     fn longest_filter(&self) -> bool;
     fn val_terminator(&self) -> Option<&'e str>;
 }

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -10,7 +10,7 @@ use std::os::unix::ffi::OsStrExt;
 
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
-use vec_map::VecMap;
+use map::VecMap;
 
 use usage_parser::UsageParser;
 use args::settings::ArgSettings;

--- a/src/args/arg_builder/flag.rs
+++ b/src/args/arg_builder/flag.rs
@@ -6,12 +6,10 @@ use std::result::Result as StdResult;
 use std::ffi::{OsStr, OsString};
 use std::mem;
 
-// Third Party
-use vec_map::{self, VecMap};
-
 // Internal
 use Arg;
 use args::{ArgSettings, Base, Switched, AnyArg, DispOrder};
+use map::{self, VecMap};
 
 #[derive(Default, Clone, Debug)]
 #[doc(hidden)]
@@ -82,7 +80,7 @@ impl<'n, 'e> AnyArg<'n, 'e> for FlagBuilder<'n, 'e> {
     fn long_help(&self) -> Option<&'e str> { self.b.long_help }
     fn val_terminator(&self) -> Option<&'e str> { None }
     fn default_val(&self) -> Option<&'e OsStr> { None }
-    fn default_vals_ifs(&self) -> Option<vec_map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
+    fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         None
     }
     fn longest_filter(&self) -> bool { self.s.long.is_some() }

--- a/src/args/arg_builder/option.rs
+++ b/src/args/arg_builder/option.rs
@@ -5,11 +5,9 @@ use std::result::Result as StdResult;
 use std::ffi::{OsStr, OsString};
 use std::mem;
 
-// Third Party
-use vec_map::{self, VecMap};
-
 // Internal
 use args::{ArgSettings, AnyArg, Base, Switched, Valued, Arg, DispOrder};
+use map::{self, VecMap};
 
 #[allow(missing_debug_implementations)]
 #[doc(hidden)]
@@ -131,7 +129,7 @@ impl<'n, 'e> AnyArg<'n, 'e> for OptBuilder<'n, 'e> {
     fn help(&self) -> Option<&'e str> { self.b.help }
     fn long_help(&self) -> Option<&'e str> { self.b.long_help }
     fn default_val(&self) -> Option<&'e OsStr> { self.v.default_val }
-    fn default_vals_ifs(&self) -> Option<vec_map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
+    fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         self.v.default_vals_ifs.as_ref().map(|vm| vm.values())
     }
     fn longest_filter(&self) -> bool { true }
@@ -165,7 +163,7 @@ impl<'n, 'e> PartialEq for OptBuilder<'n, 'e> {
 mod test {
     use args::settings::ArgSettings;
     use super::OptBuilder;
-    use vec_map::VecMap;
+    use map::VecMap;
 
     #[test]
     fn optbuilder_display1() {

--- a/src/args/arg_builder/positional.rs
+++ b/src/args/arg_builder/positional.rs
@@ -6,13 +6,11 @@ use std::result::Result as StdResult;
 use std::ffi::{OsStr, OsString};
 use std::mem;
 
-// Third Party
-use vec_map::{self, VecMap};
-
 // Internal
 use Arg;
 use args::{ArgSettings, Base, Valued, AnyArg, DispOrder};
 use INTERNAL_ERROR_MSG;
+use map::{self, VecMap};
 
 #[allow(missing_debug_implementations)]
 #[doc(hidden)]
@@ -141,7 +139,7 @@ impl<'n, 'e> AnyArg<'n, 'e> for PosBuilder<'n, 'e> {
     fn takes_value(&self) -> bool { true }
     fn help(&self) -> Option<&'e str> { self.b.help }
     fn long_help(&self) -> Option<&'e str> { self.b.long_help }
-    fn default_vals_ifs(&self) -> Option<vec_map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
+    fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         self.v.default_vals_ifs.as_ref().map(|vm| vm.values())
     }
     fn default_val(&self) -> Option<&'e OsStr> { self.v.default_val }
@@ -161,7 +159,7 @@ impl<'n, 'e> PartialEq for PosBuilder<'n, 'e> {
 mod test {
     use args::settings::ArgSettings;
     use super::PosBuilder;
-    use vec_map::VecMap;
+    use map::VecMap;
 
     #[test]
     fn display_mult() {

--- a/src/args/arg_builder/valued.rs
+++ b/src/args/arg_builder/valued.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::ffi::{OsStr, OsString};
 
-use vec_map::VecMap;
+use map::VecMap;
 
 use Arg;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,6 +538,7 @@ extern crate yaml_rust;
 extern crate unicode_width;
 #[macro_use]
 extern crate bitflags;
+#[cfg(feature = "vec_map")]
 extern crate vec_map;
 #[cfg(feature = "wrap_help")]
 extern crate term_size;
@@ -564,6 +565,7 @@ mod errors;
 mod osstringext;
 mod strext;
 mod completions;
+mod map;
 
 const INTERNAL_ERROR_MSG: &'static str = "Fatal internal error. Please consider filing a bug \
                                           report at https://github.com/kbknapp/clap-rs/issues";

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,84 @@
+#[cfg(feature = "vec_map")]
+pub use vec_map::{VecMap, Values};
+
+#[cfg(not(feature = "vec_map"))]
+pub use self::vec_map::{VecMap, Values};
+
+#[cfg(not(feature = "vec_map"))]
+mod vec_map {
+    use std::collections::BTreeMap;
+    use std::collections::btree_map;
+    use std::fmt::{self, Debug, Formatter};
+
+    #[derive(Clone, Default, Debug)]
+    pub struct VecMap<V> {
+        inner: BTreeMap<usize, V>,
+    }
+
+    impl<V> VecMap<V> {
+        pub fn new() -> Self {
+            VecMap { inner: Default::default() }
+        }
+
+        pub fn len(&self) -> usize {
+            self.inner.len()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.inner.is_empty()
+        }
+
+        pub fn insert(&mut self, key: usize, value: V) -> Option<V> {
+            self.inner.insert(key, value)
+        }
+
+        pub fn values(&self) -> Values<V> {
+            self.inner.values()
+        }
+
+        pub fn iter(&self) -> Iter<V> {
+            Iter { inner: self.inner.iter() }
+        }
+
+        pub fn contains_key(&self, key: usize) -> bool {
+            self.inner.contains_key(&key)
+        }
+
+        pub fn entry(&mut self, key: usize) -> Entry<V> {
+            self.inner.entry(key)
+        }
+
+        pub fn get(&self, key: usize) -> Option<&V> {
+            self.inner.get(&key)
+        }
+    }
+
+    pub type Values<'a, V> = btree_map::Values<'a, usize, V>;
+
+    pub type Entry<'a, V> = btree_map::Entry<'a, usize, V>;
+
+    #[derive(Clone)]
+    pub struct Iter<'a, V: 'a> {
+        inner: btree_map::Iter<'a, usize, V>,
+    }
+
+    impl<'a, V: 'a + Debug> Debug for Iter<'a, V> {
+        fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+            f.debug_list().entries(self.inner.clone()).finish()
+        }
+    }
+
+    impl<'a, V: 'a> Iterator for Iter<'a, V> {
+        type Item = (usize, &'a V);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next().map(|(k, v)| (*k, v))
+        }
+    }
+
+    impl<'a, V: 'a> DoubleEndedIterator for Iter<'a, V> {
+        fn next_back(&mut self) -> Option<Self::Item> {
+            self.inner.next_back().map(|(k, v)| (*k, v))
+        }
+    }
+}

--- a/src/usage_parser.rs
+++ b/src/usage_parser.rs
@@ -1,10 +1,9 @@
-// Third Party
-use vec_map::VecMap;
 
 // Internal
 use INTERNAL_ERROR_MSG;
 use args::Arg;
 use args::settings::ArgSettings;
+use map::VecMap;
 
 #[derive(PartialEq, Debug)]
 enum UsageToken {


### PR DESCRIPTION
This makes vec_map optional. vec_map is enabled by default. An implementation using BTreeMap is used if vec_map is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1051)
<!-- Reviewable:end -->
