### PR TITLE
Keep README version numbers in sync with crate version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ before_script:
   - |
     pip install git+git://github.com/kbknapp/travis-cargo.git --user &&
     export PATH=$HOME/.local/bin:$PATH
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == "1.13.0" ]]; then
+        echo "Old Rust detected, removing version-sync dependency"
+        sed -i "/^version-sync =/d" Cargo.toml
+        rm "tests/version-numbers.rs"
+    fi
 script:
   - |
     travis-cargo test -- --verbose --no-default-features &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ atty      = { version = "0.2.2",  optional = true }
 [dev-dependencies]
 regex = "0.2"
 lazy_static = "0.2"
+version-sync = "0.3"
 
 [features]
 default     = ["suggestions", "color", "wrap_help"]

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ For full usage, add `clap` as a dependency in your `Cargo.toml` () to use from c
 
 ```toml
 [dependencies]
-clap = "~2.19.0"
+clap = "~2.26"
 ```
 
 (**note**: If you are concerned with supporting a minimum version of Rust that is *older* than the current stable Rust minus 2 stable releases, it's recommended to use the `~major.minor.patch` style versions in your `Cargo.toml` which will only update the patch version automatically. For more information see the [Compatibility Policy](#compatibility-policy))
@@ -495,7 +495,7 @@ To disable these, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies.clap]
-version = "2.19"
+version = "2.26"
 default-features = false
 ```
 
@@ -503,7 +503,7 @@ You can also selectively enable only the features you'd like to include, by addi
 
 ```toml
 [dependencies.clap]
-version = "2.19"
+version = "2.26"
 default-features = false
 
 # Cherry-pick the features you'd like to use
@@ -629,7 +629,7 @@ In order to keep from being surprised of breaking changes, it is **highly** reco
 
 ```toml
 [dependencies]
-clap = "~2.19.0"
+clap = "~2.26"
 ```
 
 This will cause *only* the patch version to be updated upon a `cargo update` call, and therefore cannot break due to new features, or bumped minimum versions of Rust.

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ From @alexcrichton:
 
 Right now Cargo's version resolution is pretty naive, it's just a brute-force search of the solution space, returning the first resolvable graph. This also means that it currently won't terminate until it proves there is not possible resolvable graph. This leads to situations where workspaces with multiple binaries, for example, have two different dependencies such as:
 
-```toml
+```toml,no_sync
 
 # In one Cargo.toml
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,6 +511,7 @@
 //! this repository for more information.
 
 #![crate_type= "lib"]
+#![doc(html_root_url = "https://docs.rs/clap/2.26.2")]
 #![deny(
         missing_docs,
         missing_debug_implementations,

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,7 @@
+#[macro_use]
+extern crate version_sync;
+
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -5,3 +5,8 @@ extern crate version_sync;
 fn test_readme_deps() {
     assert_markdown_deps_updated!("README.md");
 }
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
Hi @kbknapp. I noticed that I tend to forget to update the version numbers in the TOML examples in my README files when I do a release, so I wrote a small crate that makes it easy to add an integration test for this: [version-sync][1].

It can check the typical
~~~markdown
```toml
[dependencies]
clap = "~2.26"
```
~~~

blocks in your README. If the version number doesn't match the crate version, the test fails. Since `version-sync` only works on Rust 1.15 and later, I remove the dependency when Travis tests with version 1.13.0 — that's a bit of a hack, but it should work okay.

I've updated your README to match the current crate version and then added an integration test. I hope you find it useful!

[1]: https://crates.io/crates/version-sync

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1053)
<!-- Reviewable:end -->
