### PR TITLE
Reduce amount of unsafe code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: rust
 cache: cargo
 rust:
   - nightly
-  - nightly-2017-01-25
+  - nightly-2017-06-07
   - beta
   - stable
-  - 1.13.0
+  - 1.18.0
 matrix:
     allow_failures:
         - rust: nightly

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -847,12 +847,11 @@ impl<'a> Help<'a> {
                 _ => continue,
             };
 
-            debugln!("Help::write_template_help:iter: tag_buf={};", unsafe {
-                String::from_utf8_unchecked(tag_buf.get_ref()[0..tag_length]
-                                                .iter()
-                                                .map(|&i| i)
-                                                .collect::<Vec<_>>())
-            });
+            debugln!(
+                "Help::write_template_help:iter: tag_buf={};",
+                str::from_utf8(&tag_buf.get_ref()[..tag_length])
+                    .unwrap_or_default()
+            );
             match &tag_buf.get_ref()[0..tag_length] {
                 b"?" => {
                     self.writer.write_all(b"Could not decode tag name")?;

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1352,7 +1352,7 @@ impl<'a, 'b> Parser<'a, 'b>
         match Help::write_parser_help(&mut buf, self, use_long) {
             Err(e) => e,
             _ => Error {
-                message: unsafe { String::from_utf8_unchecked(buf) },
+                message: String::from_utf8(buf).unwrap_or_default(),
                 kind: ErrorKind::HelpDisplayed,
                 info: None,
             }
@@ -1566,7 +1566,7 @@ impl<'a, 'b> Parser<'a, 'b>
         if no_val && min_vals_zero && !has_eq && needs_eq {
             debugln!("Parser::parse_opt: More arg vals not required...");
             return Ok(ParseResult::ValuesDone);
-        } else if no_val || (mult && !needs_delim) && !has_eq && matcher.needs_more_vals(opt) { 
+        } else if no_val || (mult && !needs_delim) && !has_eq && matcher.needs_more_vals(opt) {
             debugln!("Parser::parse_opt: More arg vals required...");
             return Ok(ParseResult::Opt(opt.b.name));
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -444,9 +444,7 @@ macro_rules! crate_authors {
             }
         }
 
-        static CARGO_AUTHORS: CargoAuthors = CargoAuthors { __private_field: () };
-
-        &*CARGO_AUTHORS
+        &*CargoAuthors { __private_field: () }
     }};
     () => {
         env!("CARGO_PKG_AUTHORS")


### PR DESCRIPTION
This PR addresses most of https://github.com/kbknapp/clap-rs/issues/1054.

* [cad2e64](https://github.com/H2CO3/clap-rs/commit/cad2e64bdf57fa0ab01317a50e4d4276fa467931) replaces two instances of `from_utf8_unchecked()` with `from_utf8().unwrap_or_default()`. The method `unwrap_or_default()` is used instead of a plain `unwrap()` in order not to crash client code if invalid UTF-8 ever comes out of the library (which should theoretically never happen, but never say never). Since one string is just a debug message, the other one is a supplementary error message, getting an empty string instead of a crash or invalid UTF-8 should be acceptable.
For printing the error message, the function `str::from_ut8` is used instead of `String::from_utf8` because there's no point in allocating a string, printing it, then immediately dropping it – a slice is perfectly fine for printing a string locally.
* [4cb8237](https://github.com/H2CO3/clap-rs/commit/4cb8237e08a11cee56575c78e342b0dad2e041d9) re-organizes the initialization of the lazy `static` in the `crate_authors` macro. I couldn't figure out a non-breaking way of keeping it `static` **and** replacing it with safe code; nevertheless, the types and the implementation of `Deref` have been rewritten in a functionally equivalent but a bit more readable (and, with regards to the type name, more idiomatic) manner. The scope of the `unsafe` block has been reduced, too.
* It turns out that `OsStr` (still) doesn't have the implementation of `from_bytes()` and `as_bytes()` in the standard library on Windows (the `OsStrExt` trait that defines these is in `std::os::unix::ffi`), so that particular use of `unsafe` must remain… However, the implementation using `mem::transmute()` is identical to that of the stdlib, so this shouldn't be too bad, after all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1058)
<!-- Reviewable:end -->
