### PR TITLE
always add env parameter when passed

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -1,4 +1,5 @@
 // Std
+use std::borrow::Cow;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -501,7 +502,7 @@ impl<'a> Help<'a> {
             spec_vals.push(format!(
                 " [env:{}: {}]",
                 env.0.to_string_lossy(),
-                env.1.to_string_lossy()
+                env.1.map_or(Cow::Borrowed(""), |val| val.to_string_lossy())
             ));
         }
         if !a.is_set(ArgSettings::HideDefaultValue) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1796,7 +1796,7 @@ impl<'n, 'e> AnyArg<'n, 'e> for App<'n, 'e> {
     fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         None
     }
-    fn env<'s>(&'s self) -> Option<(&'n OsStr, &'s OsString)> { None }
+    fn env<'s>(&'s self) -> Option<(&'n OsStr, Option<&'s OsString>)> { None }
     fn longest_filter(&self) -> bool { true }
     fn aliases(&self) -> Option<Vec<&'e str>> {
         if let Some(ref aliases) = self.p.meta.aliases {

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1794,18 +1794,22 @@ impl<'a, 'b> Parser<'a, 'b>
             ($_self:ident, $a:ident, $m:ident) => {
                 if let Some(ref val) = $a.v.env {
                     if $m.get($a.b.name).map(|ma| ma.vals.len()).map(|len| len == 0).unwrap_or(false) {
-                        $_self.add_val_to_arg($a, OsStr::new(&val.1), $m)?;
+                        if let Some(ref val) = val.1 {
+                            $_self.add_val_to_arg($a, OsStr::new(val), $m)?;
 
-                        if $_self.cache.map_or(true, |name| name != $a.name()) {
-                            arg_post_processing!($_self, $a, $m);
-                            $_self.cache = Some($a.name());
+                            if $_self.cache.map_or(true, |name| name != $a.name()) {
+                                arg_post_processing!($_self, $a, $m);
+                                $_self.cache = Some($a.name());
+                            }
                         }
                     } else {
-                        $_self.add_val_to_arg($a, OsStr::new(&val.1), $m)?;
+                        if let Some(ref val) = val.1 {
+                            $_self.add_val_to_arg($a, OsStr::new(val), $m)?;
 
-                        if $_self.cache.map_or(true, |name| name != $a.name()) {
-                            arg_post_processing!($_self, $a, $m);
-                            $_self.cache = Some($a.name());
+                            if $_self.cache.map_or(true, |name| name != $a.name()) {
+                                arg_post_processing!($_self, $a, $m);
+                                $_self.cache = Some($a.name());
+                            }
                         }
                     }
                 }

--- a/src/args/any_arg.rs
+++ b/src/args/any_arg.rs
@@ -33,7 +33,7 @@ pub trait AnyArg<'n, 'e>: std_fmt::Display {
     fn long_help(&self) -> Option<&'e str>;
     fn default_val(&self) -> Option<&'e OsStr>;
     fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>>;
-    fn env<'s>(&'s self) -> Option<(&'n OsStr, &'s OsString)>;
+    fn env<'s>(&'s self) -> Option<(&'n OsStr, Option<&'s OsString>)>;
     fn longest_filter(&self) -> bool;
     fn val_terminator(&self) -> Option<&'e str>;
 }

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -3421,7 +3421,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     pub fn env_os(mut self, name: &'a OsStr) -> Self {
         self.setb(ArgSettings::TakesValue);
 
-        self.v.env = env::var_os(name).map(|value| (name, value));
+        self.v.env = Some((name, env::var_os(name)));
         self
     }
 

--- a/src/args/arg_builder/flag.rs
+++ b/src/args/arg_builder/flag.rs
@@ -89,7 +89,7 @@ impl<'n, 'e> AnyArg<'n, 'e> for FlagBuilder<'n, 'e> {
     fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         None
     }
-    fn env<'s>(&'s self) -> Option<(&'n OsStr, &'s OsString)> { None }
+    fn env<'s>(&'s self) -> Option<(&'n OsStr, Option<&'s OsString>)> { None }
     fn longest_filter(&self) -> bool { self.s.long.is_some() }
     fn aliases(&self) -> Option<Vec<&'e str>> {
         if let Some(ref aliases) = self.s.aliases {

--- a/src/args/arg_builder/option.rs
+++ b/src/args/arg_builder/option.rs
@@ -140,8 +140,11 @@ impl<'n, 'e> AnyArg<'n, 'e> for OptBuilder<'n, 'e> {
     fn default_vals_ifs(&self) -> Option<map::Values<(&'n str, Option<&'e OsStr>, &'e OsStr)>> {
         self.v.default_vals_ifs.as_ref().map(|vm| vm.values())
     }
-    fn env<'s>(&'s self) -> Option<(&'n OsStr, &'s OsString)> {
-        self.v.env.as_ref().map(|&(key, ref value)| (key, value))
+    fn env<'s>(&'s self) -> Option<(&'n OsStr, Option<&'s OsString>)> {
+        self.v
+            .env
+            .as_ref()
+            .map(|&(key, ref value)| (key, value.as_ref()))
     }
     fn longest_filter(&self) -> bool { true }
     fn aliases(&self) -> Option<Vec<&'e str>> {

--- a/src/args/arg_builder/positional.rs
+++ b/src/args/arg_builder/positional.rs
@@ -39,8 +39,8 @@ impl<'n, 'e> PosBuilder<'n, 'e> {
             v: Valued::from(a),
             index: idx,
         };
-        if a.v.max_vals.is_some() || a.v.min_vals.is_some() ||
-            (a.v.num_vals.is_some() && a.v.num_vals.unwrap() > 1)
+        if a.v.max_vals.is_some() || a.v.min_vals.is_some()
+            || (a.v.num_vals.is_some() && a.v.num_vals.unwrap() > 1)
         {
             pb.b.settings.set(ArgSettings::Multiple);
         }
@@ -48,8 +48,8 @@ impl<'n, 'e> PosBuilder<'n, 'e> {
     }
 
     pub fn from_arg(mut a: Arg<'n, 'e>, idx: u64) -> Self {
-        if a.v.max_vals.is_some() || a.v.min_vals.is_some() ||
-            (a.v.num_vals.is_some() && a.v.num_vals.unwrap() > 1)
+        if a.v.max_vals.is_some() || a.v.min_vals.is_some()
+            || (a.v.num_vals.is_some() && a.v.num_vals.unwrap() > 1)
         {
             a.b.settings.set(ArgSettings::Multiple);
         }
@@ -109,8 +109,8 @@ impl<'n, 'e> Display for PosBuilder<'n, 'e> {
         } else {
             write!(f, "<{}>", self.b.name)?;
         }
-        if self.b.settings.is_set(ArgSettings::Multiple) &&
-            (self.v.val_names.is_none() || self.v.val_names.as_ref().unwrap().len() == 1)
+        if self.b.settings.is_set(ArgSettings::Multiple)
+            && (self.v.val_names.is_none() || self.v.val_names.as_ref().unwrap().len() == 1)
         {
             write!(f, "...")?;
         }
@@ -152,11 +152,11 @@ impl<'n, 'e> AnyArg<'n, 'e> for PosBuilder<'n, 'e> {
         self.v.default_vals_ifs.as_ref().map(|vm| vm.values())
     }
     fn default_val(&self) -> Option<&'e OsStr> { self.v.default_val }
-    fn env<'s>(&'s self) -> Option<(&'n OsStr, &'s OsString)> {
+    fn env<'s>(&'s self) -> Option<(&'n OsStr, Option<&'s OsString>)> {
         self.v
             .env
             .as_ref()
-            .map(|&(key, ref value)| (key, value))
+            .map(|&(key, ref value)| (key, value.as_ref()))
     }
     fn longest_filter(&self) -> bool { true }
     fn aliases(&self) -> Option<Vec<&'e str>> { None }

--- a/src/args/arg_builder/valued.rs
+++ b/src/args/arg_builder/valued.rs
@@ -21,7 +21,7 @@ where
     pub val_delim: Option<char>,
     pub default_val: Option<&'b OsStr>,
     pub default_vals_ifs: Option<VecMap<(&'a str, Option<&'b OsStr>, &'b OsStr)>>,
-    pub env: Option<(&'a OsStr, OsString)>,
+    pub env: Option<(&'a OsStr, Option<OsString>)>,
     pub terminator: Option<&'b str>,
 }
 


### PR DESCRIPTION
I noticed while using the new `Arg::env` feature, that the help string wouldn't display the env parameter as an option if it was not set in the environment.

It will now look like this:

```console
--opt <OPT>         Opt description [env:OPT_ENV: ]  [default: opt]
```

I wasn't sure what to put when not present so I went with `""`, the empty string. Let me know if you have other thoughts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1065)
<!-- Reviewable:end -->
