### PR TITLE
Support trailing comma in arg_enum! fields

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -345,6 +345,14 @@ macro_rules! arg_enum {
             }
         });
     };
+    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(@impls
+            ($(#[$($m),+])+
+            pub enum $e {
+                $($v$(=$val)*),+
+            }) -> ($e, $($v),+)
+        );
+    };
     ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
             ($(#[$($m),+])+
@@ -353,7 +361,14 @@ macro_rules! arg_enum {
             }) -> ($e, $($v),+)
         );
     };
-    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*),+  } ) => {
+    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!($(#[$($m:meta),+])+
+            enum $e:ident {
+                $($v:ident $(=$val:expr)*),+
+            }
+        );
+    };
+    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
             ($(#[$($m),+])+
             enum $e {
@@ -361,12 +376,22 @@ macro_rules! arg_enum {
             }) -> ($e, $($v),+)
         );
     };
+    (pub enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(pub enum $e:ident {
+            $($v:ident $(=$val:expr)*),+
+        });
+    };
     (pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
             (pub enum $e {
                 $($v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
+    };
+    (enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+        arg_enum!(enum $e:ident {
+            $($v:ident $(=$val:expr)*),+
+        });
     };
     (enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -159,3 +159,15 @@ fn arg_enum() {
     }
     assert_eq!("Alpha".parse::<Greek>(), Ok(Greek::Alpha));
 }
+
+#[test]
+fn arg_enum_trailing_comma() {
+    arg_enum!{
+        #[derive(Debug, PartialEq, Copy, Clone)]
+        pub enum Greek {
+            Alpha,
+            Bravo,
+        }
+    }
+    assert_eq!("Alpha".parse::<Greek>(), Ok(Greek::Alpha));
+}


### PR DESCRIPTION
This resolves #1097. A test was also included. Let me know if you'd like more tests or tweaks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1124)
<!-- Reviewable:end -->
