### PR TITLE
Fix completion of long option values in Zsh

### DIFF
--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -371,7 +371,7 @@ fn write_opts_of(p: &Parser) -> String {
         }
         if let Some(long) = o.long() {
             let l = format!(
-                "'{conflicts}{multiple}--{arg}+[{help}]{possible_values}' \\",
+                "'{conflicts}{multiple}--{arg}=[{help}]{possible_values}' \\",
                 conflicts = conflicts,
                 multiple = multiple,
                 arg = long,

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -108,7 +108,7 @@ _myapp() {
         case $line[1] in
             (test)
 _arguments -s -S -C \
-'--case+[the case to test]' \
+'--case=[the case to test]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -397,7 +397,7 @@ _my_app() {
         case $line[1] in
             (test)
 _arguments -s -S -C \
-'--case+[the case to test]' \
+'--case=[the case to test]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -406,7 +406,7 @@ _arguments -s -S -C \
 ;;
 (some_cmd)
 _arguments -s -S -C \
-'--config+[the other case to test]' \
+'--config=[the other case to test]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \


### PR DESCRIPTION
Long options take their argument either in the next word or after an equals sign, but the Zsh completion specified that they take it either in the same word with no separator or in the next word. See the documentation of the [Zsh _arguments function](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Completion-Functions) for more information.

### Sample for testing
```rust
extern crate clap;

use std::io;
use clap::{App, Arg, Shell};

fn build_cli() -> App<'static, 'static> {
    App::new("clap-test")
        .arg(Arg::with_name("wat")
            .long("wat")
            .takes_value(true)
            .possible_values(&["foo", "bar"]))
        .arg(Arg::with_name("completions")
            .long("completions"))
}

fn main() {
    let matches = build_cli().get_matches();

    if matches.is_present("completions") {
        build_cli().gen_completions_to("clap-test", Shell::Zsh, &mut io::stdout())
    }

    if let Some(wat) = matches.value_of("wat") {
        println!("{}", wat);
    }
}
```

Related #850

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1141)
<!-- Reviewable:end -->

  