### PR TITLE
Zsh completion improvements

### DIFF
--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -33,7 +33,14 @@ impl<'a, 'b> ZshGen<'a, 'b> {
 
 _{name}() {{
     typeset -A opt_args
+    typeset -a _arguments_options
     local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
 
     local context curcontext=\"$curcontext\" state line
     {initial_args}
@@ -275,7 +282,7 @@ fn parser_of<'a, 'b>(p: &'b Parser<'a, 'b>, sc: &str) -> &'b Parser<'a, 'b> {
 //    -S: Do not complete anything after '--' and treat those as argument values
 fn get_args_of(p: &Parser) -> String {
     debugln!("get_args_of;");
-    let mut ret = vec![String::from("_arguments -s -S -C \\")];
+    let mut ret = vec![String::from("_arguments \"${_arguments_options[@]}\" \\")];
     let opts = write_opts_of(p);
     let flags = write_flags_of(p);
     let positionals = write_positionals_of(p);

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -31,6 +31,8 @@ impl<'a, 'b> ZshGen<'a, 'b> {
                 "\
 #compdef {name}
 
+autoload -U is-at-least
+
 _{name}() {{
     typeset -A opt_args
     typeset -a _arguments_options

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -360,7 +360,8 @@ fn write_opts_of(p: &Parser) -> String {
             ""
         };
         let pv = if let Some(pv_vec) = o.possible_vals() {
-            format!(": :({})", pv_vec.join(" "))
+            format!(": :({})", pv_vec.iter().map(
+                |v| escape_value(*v)).collect::<Vec<String>>().join(" "))
         } else {
             String::new()
         };

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -230,15 +230,18 @@ fn get_subcommands_of(p: &Parser) -> String {
     format!(
         "case $state in
     ({name})
-        curcontext=\"${{curcontext%:*:*}}:{name_hyphen}-command-$words[1]:\"
-        case $line[1] in
+        words=($line[{pos}] \"${{words[@]}}\")
+        (( CURRENT += 1 ))
+        curcontext=\"${{curcontext%:*:*}}:{name_hyphen}-command-$line[{pos}]:\"
+        case $line[{pos}] in
             {subcommands}
         esac
     ;;
 esac",
         name = p.meta.name,
         name_hyphen = p.meta.bin_name.as_ref().unwrap().replace(" ", "-"),
-        subcommands = subcmds.join("\n")
+        subcommands = subcmds.join("\n"),
+        pos = p.positionals().len() + 1
     )
 }
 
@@ -285,7 +288,7 @@ fn get_args_of(p: &Parser) -> String {
         String::new()
     };
     let sc = if p.has_subcommands() {
-        format!("\"*:: :->{name}\" \\", name = p.meta.name)
+        format!("\"*::: :->{name}\" \\", name = p.meta.name)
     } else {
         String::new()
     };

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -61,7 +61,7 @@ _{name} \"$@\"",
     }
 }
 
-// Displays the positional args and commands of a subcommand
+// Displays the commands of a subcommand
 // (( $+functions[_[bin_name_underscore]_commands] )) ||
 // _[bin_name_underscore]_commands() {
 // 	local commands; commands=(
@@ -72,8 +72,8 @@ _{name} \"$@\"",
 // Where the following variables are present:
 //    [bin_name_underscore]: The full space deliniated bin_name, where spaces have been replaced by
 //                           underscore characters
-//    [arg_name]: The name of the positional arg or subcommand
-//    [arg_help]: The help message of the arg or subcommand
+//    [arg_name]: The name of the subcommand
+//    [arg_help]: The help message of the subcommand
 //    [bin_name]: The full space deliniated bin_name
 //
 // Here's a snippet from rustup:
@@ -103,7 +103,7 @@ _{bin_name_underscore}_commands() {{
 }}",
             bin_name_underscore = p.meta.bin_name.as_ref().unwrap().replace(" ", "__"),
             bin_name = p.meta.bin_name.as_ref().unwrap(),
-            subcommands_and_args = subcommands_and_args_of(p)
+            subcommands_and_args = subcommands_of(p)
         ),
     ];
 
@@ -124,26 +124,26 @@ _{bin_name_underscore}_commands() {{
 }}",
             bin_name_underscore = bin_name.replace(" ", "__"),
             bin_name = bin_name,
-            subcommands_and_args = subcommands_and_args_of(parser_of(p, bin_name))
+            subcommands_and_args = subcommands_of(parser_of(p, bin_name))
         ));
     }
 
     ret.join("\n")
 }
 
-// Generates subcommand and positional argument completions in form of
+// Generates subcommand completions in form of
 //
 // 		'[arg_name]:[arg_help]'
 //
 // Where:
-//    [arg_name]: the argument or subcommand's name
-//    [arg_help]: the help message of the argument or subcommand
+//    [arg_name]: the subcommand's name
+//    [arg_help]: the help message of the subcommand
 //
 // A snippet from rustup:
 // 		'show:Show the active and installed toolchains'
 //      'update:Update Rust toolchains'
-fn subcommands_and_args_of(p: &Parser) -> String {
-    debugln!("ZshGen::subcommands_and_args_of;");
+fn subcommands_of(p: &Parser) -> String {
+    debugln!("ZshGen::subcommands_of;");
     let mut ret = vec![];
     fn add_sc(sc: &App, n: &str, ret: &mut Vec<String>) {
         debugln!("ZshGen::add_sc;");
@@ -162,10 +162,10 @@ fn subcommands_and_args_of(p: &Parser) -> String {
         }
     }
 
-    // First the subcommands
+    // The subcommands
     for sc in p.subcommands() {
         debugln!(
-            "ZshGen::subcommands_and_args_of:iter: subcommand={}",
+            "ZshGen::subcommands_of:iter: subcommand={}",
             sc.p.meta.name
         );
         add_sc(sc, &sc.p.meta.name, &mut ret);
@@ -262,8 +262,8 @@ fn parser_of<'a, 'b>(p: &'b Parser<'a, 'b>, sc: &str) -> &'b Parser<'a, 'b> {
     &p.find_subcommand(sc).expect(INTERNAL_ERROR_MSG).p
 }
 
-// Writes out the args section, which ends up being the flags and opts, and a jump to
-// another ZSH function if there are positional args or subcommands.
+// Writes out the args section, which ends up being the flags, opts and postionals, and a jump to
+// another ZSH function if there are subcommands.
 // The structer works like this:
 //    ([conflicting_args]) [multiple] arg [takes_value] [[help]] [: :(possible_values)]
 //       ^-- list '-v -h'    ^--'*'          ^--'+'                   ^-- list 'one two three'
@@ -274,8 +274,8 @@ fn parser_of<'a, 'b>(p: &'b Parser<'a, 'b>, sc: &str) -> &'b Parser<'a, 'b> {
 // 		'(-h --help --verbose)-v[Enable verbose output]' \
 // 		'(-V -v --version --verbose --help)-h[Prints help information]' \
 //      # ... snip for brevity
-// 		'1:: :_rustup_commands' \   # <-- displays positional args and subcommands
-// 		'*:: :->rustup' \           # <-- displays subcommand args and child subcommands
+// 		':: :_rustup_commands' \    # <-- displays subcommands
+// 		'*::: :->rustup' \          # <-- displays subcommand args and child subcommands
 // 	&& ret=0
 //
 // The args used for _arguments are as follows:

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -99,7 +99,8 @@ _myapp() {
 '--help[Prints help information]' \
 '-V[Prints version information]' \
 '--version[Prints version information]' \
-"1:: :_myapp_commands" \
+"::file -- some input file:_files" \
+":: :_myapp_commands" \
 "*:: :->myapp" \
 && ret=0
     case $state in
@@ -133,7 +134,6 @@ _myapp_commands() {
     local commands; commands=(
         "test:tests things" \
 "help:Prints this message or the help of the given subcommand(s)" \
-"FILE:some input file" \
     )
     _describe -t commands 'myapp commands' commands "$@"
 }
@@ -388,7 +388,8 @@ _my_app() {
 '--help[Prints help information]' \
 '-V[Prints version information]' \
 '--version[Prints version information]' \
-"1:: :_my_app_commands" \
+"::file -- some input file:_files" \
+":: :_my_app_commands" \
 "*:: :->my_app" \
 && ret=0
     case $state in
@@ -441,7 +442,6 @@ _my_app_commands() {
 "some_cmd:tests other things" \
 "some-cmd-with-hypens:" \
 "help:Prints this message or the help of the given subcommand(s)" \
-"FILE:some input file" \
     )
     _describe -t commands 'my_app commands' commands "$@"
 }

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -89,6 +89,8 @@ complete -F _myapp -o bashdefault -o default myapp
 
 static ZSH: &'static str = r#"#compdef myapp
 
+autoload -U is-at-least
+
 _myapp() {
     typeset -A opt_args
     typeset -a _arguments_options
@@ -387,6 +389,8 @@ static POWERSHELL_SPECIAL_CMDS: &'static str = r#"
 
 static ZSH_SPECIAL_CMDS: &'static str = r#"#compdef my_app
 
+autoload -U is-at-least
+
 _my_app() {
     typeset -A opt_args
     typeset -a _arguments_options
@@ -672,6 +676,8 @@ complete -c my_app -n "__fish_using_command my_app" -s V -l version -d 'Prints v
 "#;
 
 static ZSH_SPECIAL_HELP: &'static str = r#"#compdef my_app
+
+autoload -U is-at-least
 
 _my_app() {
     typeset -A opt_args

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -101,12 +101,14 @@ _myapp() {
 '--version[Prints version information]' \
 "::file -- some input file:_files" \
 ":: :_myapp_commands" \
-"*:: :->myapp" \
+"*::: :->myapp" \
 && ret=0
     case $state in
     (myapp)
-        curcontext="${curcontext%:*:*}:myapp-command-$words[1]:"
-        case $line[1] in
+        words=($line[2] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:myapp-command-$line[2]:"
+        case $line[2] in
             (test)
 _arguments -s -S -C \
 '--case=[the case to test]' \
@@ -390,12 +392,14 @@ _my_app() {
 '--version[Prints version information]' \
 "::file -- some input file:_files" \
 ":: :_my_app_commands" \
-"*:: :->my_app" \
+"*::: :->my_app" \
 && ret=0
     case $state in
     (my_app)
-        curcontext="${curcontext%:*:*}:my_app-command-$words[1]:"
-        case $line[1] in
+        words=($line[2] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:my_app-command-$line[2]:"
+        case $line[2] in
             (test)
 _arguments -s -S -C \
 '--case=[the case to test]' \

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -91,10 +91,17 @@ static ZSH: &'static str = r#"#compdef myapp
 
 _myapp() {
     typeset -A opt_args
+    typeset -a _arguments_options
     local ret=1
 
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
     local context curcontext="$curcontext" state line
-    _arguments -s -S -C \
+    _arguments "${_arguments_options[@]}" \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -110,7 +117,7 @@ _myapp() {
         curcontext="${curcontext%:*:*}:myapp-command-$line[2]:"
         case $line[2] in
             (test)
-_arguments -s -S -C \
+_arguments "${_arguments_options[@]}" \
 '--case=[the case to test]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
@@ -119,7 +126,7 @@ _arguments -s -S -C \
 && ret=0
 ;;
 (help)
-_arguments -s -S -C \
+_arguments "${_arguments_options[@]}" \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -382,10 +389,17 @@ static ZSH_SPECIAL_CMDS: &'static str = r#"#compdef my_app
 
 _my_app() {
     typeset -A opt_args
+    typeset -a _arguments_options
     local ret=1
 
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
     local context curcontext="$curcontext" state line
-    _arguments -s -S -C \
+    _arguments "${_arguments_options[@]}" \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -401,7 +415,7 @@ _my_app() {
         curcontext="${curcontext%:*:*}:my_app-command-$line[2]:"
         case $line[2] in
             (test)
-_arguments -s -S -C \
+_arguments "${_arguments_options[@]}" \
 '--case=[the case to test]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
@@ -410,7 +424,7 @@ _arguments -s -S -C \
 && ret=0
 ;;
 (some_cmd)
-_arguments -s -S -C \
+_arguments "${_arguments_options[@]}" \
 '--config=[the other case to test]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
@@ -419,7 +433,7 @@ _arguments -s -S -C \
 && ret=0
 ;;
 (some-cmd-with-hypens)
-_arguments -s -S -C \
+_arguments "${_arguments_options[@]}" \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -427,7 +441,7 @@ _arguments -s -S -C \
 && ret=0
 ;;
 (help)
-_arguments -s -S -C \
+_arguments "${_arguments_options[@]}" \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -661,10 +675,17 @@ static ZSH_SPECIAL_HELP: &'static str = r#"#compdef my_app
 
 _my_app() {
     typeset -A opt_args
+    typeset -a _arguments_options
     local ret=1
 
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
     local context curcontext="$curcontext" state line
-    _arguments -s -S -C \
+    _arguments "${_arguments_options[@]}" \
 '--single-quotes[Can be '\''always'\'', '\''auto'\'', or '\''never'\'']' \
 '--double-quotes[Can be "always", "auto", or "never"]' \
 '--backticks[For more information see `echo test`]' \

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -108,7 +108,7 @@ _myapp() {
 '--help[Prints help information]' \
 '-V[Prints version information]' \
 '--version[Prints version information]' \
-"::file -- some input file:_files" \
+'::file -- some input file:_files' \
 ":: :_myapp_commands" \
 "*::: :->myapp" \
 && ret=0
@@ -408,7 +408,7 @@ _my_app() {
 '--help[Prints help information]' \
 '-V[Prints version information]' \
 '--version[Prints version information]' \
-"::file -- some input file:_files" \
+'::file -- some input file:_files' \
 ":: :_my_app_commands" \
 "*::: :->my_app" \
 && ret=0


### PR DESCRIPTION
This includes a bunch of improvements to Zsh completion, as separate commits:

1. Complete positional arguments properly

   This changes the way we complete positionals to complete them using `_arguments`, as should be done, instead of completing their uppercase name as a string.

   Currently I made it offer `_files` completion for all positional arguments. This can be improved to complete actual possible values of the arguments and only complete files if the argument truly takes them. But this will require further changes in clap to actually have the required functionality to get this information.

2. Maybe fix completions with mixed positionals and subcommands

   Optional positionals mixed with subcommands will still break this, since I can't see how to tell which element of `$line` is the command than. Mixing optional positionals with subcommands is a bit weird and awkward though...

   This is, of course, a followup of 1 since this wasn't an issue when we weren't completing positionals properly.

3. Don't pass `-S` to _arguments if Zsh is too old

   If you do pass it than `_arguments` considers `-C` as a possible option in the completions.

   This affects Ubuntu 16.04 which uses Zsh 5.1.1 for example.

Related https://github.com/kbknapp/clap-rs/issues/868

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1147)
<!-- Reviewable:end -->
