### PR TITLE
Fix typo in crate documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@
 //! For example, to test the code, as above simply run:
 //!
 //! ```text
-//! $ just run-tests`
+//! $ just run-tests
 //! ```
 //!
 //! From here on, I will lis the appropriate `cargo` command as well as the `just` command.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1159)
<!-- Reviewable:end -->
