### PR TITLE
Allow nesting of '--'

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -875,7 +875,9 @@ where
             self.unset(AS::ValidNegNumFound);
             // Is this a new argument, or values from a previous option?
             let starts_new_arg = self.is_new_arg(&arg_os, needs_val_of);
-            if arg_os.starts_with(b"--") && arg_os.len_() == 2 && starts_new_arg {
+            if !self.is_set(AS::TrailingValues) &&
+                arg_os.starts_with(b"--") && arg_os.len_() == 2 && starts_new_arg
+            {
                 debugln!("Parser::get_matches_with: setting TrailingVals=true");
                 self.set(AS::TrailingValues);
                 continue;


### PR DESCRIPTION
Suppose there is a program that executes another program, then it is convenient to take the arguments of the subprogram after `--`, as illustrated in the `22_stop_parsing_with_--.rs` example. However, if the subprogram itself wants to receive `--`, then clap-rs should allow it.

Fixes #1161.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1162)
<!-- Reviewable:end -->
