### PR TITLE
imp(Deps): doesnt compile ansi_term on Windows since its not used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,14 @@ bitflags              = "1.0"
 unicode-width         = "0.1.4"
 textwrap              = "0.9.0"
 strsim    = { version = "0.7.0",  optional = true }
-ansi_term = { version = "0.10.0",  optional = true }
 yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }
 term_size = { version = "0.3.0", optional = true }
+
+[target.'cfg(not(windows))'.dependencies]
+ansi_term = { version = "0.10.0",  optional = true }
 
 [dev-dependencies]
 regex = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,7 +528,7 @@
 #![cfg_attr(feature = "lints", allow(doc_markdown))]
 #![cfg_attr(feature = "lints", allow(explicit_iter_loop))]
 
-#[cfg(feature = "color")]
+#[cfg(all(feature = "color", not(target_os = "windows")))]
 extern crate ansi_term;
 #[cfg(feature = "color")]
 extern crate atty;


### PR DESCRIPTION
Before this commit, ansi_term was compiled anytime the `color` feature
was used. However, on Windows the `color` feature is ignored. Even so
ansi_term was compiled, and just not used. This commit fixes that by
only compiling ansi_term on non-Windows targets. Thanks to @retep998 for
the gudiance.

Closes #1155

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1178)
<!-- Reviewable:end -->
