### PR TITLE
Enable wasm32 compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,11 @@ Upon bumping the minimum version of Rust (assuming it's within the stable-2 rang
  * The breaking change is to be fixing a bug (i.e. relying on a bug as a feature)
  * The breaking change is a feature isn't used in the wild, or all users of said feature have given approval *prior* to the change
 
+#### Compatibility with Wasm
+
+A best effort is made to ensure that `clap` will work on projects targeting `wasm32-unknown-unknown`. However there is no dedicated CI build
+covering this specific target.
+
 ## License
 
 `clap` is licensed under the MIT license. Please read the [LICENSE-MIT](LICENSE-MIT) file in this repository for more information.

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -2,9 +2,9 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::ffi::{OsStr, OsString};
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 use osstringext::OsStrExt3;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use std::os::unix::ffi::OsStrExt;
 use std::env;
 
@@ -147,8 +147,7 @@ impl<'a, 'b> Arg<'a, 'b> {
                 }
                 s => panic!(
                     "Unknown Arg setting '{}' in YAML file for arg '{}'",
-                    s,
-                    name_str
+                    s, name_str
                 ),
             }
         }
@@ -1281,7 +1280,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     ///
     /// A safe thing to do if you'd like to support an option which supports multiple values, but
-    /// also is "overridable" by itself, is to use `use_delimiter(false)` and *not* use 
+    /// also is "overridable" by itself, is to use `use_delimiter(false)` and *not* use
     /// `multiple(true)` while telling users to seperate values with a comma (i.e. `val1,val2`)
     ///
     /// ```
@@ -3576,7 +3575,9 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///
     /// assert_eq!(m.values_of("flag").unwrap().collect::<Vec<_>>(), vec!["env1", "env2"]);
     /// ```
-    pub fn env(self, name: &'a str) -> Self { self.env_os(OsStr::new(name)) }
+    pub fn env(self, name: &'a str) -> Self {
+        self.env_os(OsStr::new(name))
+    }
 
     /// Specifies that if the value is not passed in as an argument, that it should be retrieved
     /// from the environment if available in the exact same manner as [`Arg::env`] only using
@@ -3589,7 +3590,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     }
 
     /// @TODO @p2 @docs @release: write docs
-    pub fn hide_env_values(self, hide: bool) -> Self { 
+    pub fn hide_env_values(self, hide: bool) -> Self {
         if hide {
             self.set(ArgSettings::HideEnvValues)
         } else {
@@ -3713,7 +3714,9 @@ impl<'a, 'b> Arg<'a, 'b> {
 
     /// Checks if one of the [`ArgSettings`] settings is set for the argument
     /// [`ArgSettings`]: ./enum.ArgSettings.html
-    pub fn is_set(&self, s: ArgSettings) -> bool { self.b.is_set(s) }
+    pub fn is_set(&self, s: ArgSettings) -> bool {
+        self.b.is_set(s)
+    }
 
     /// Sets one of the [`ArgSettings`] settings for the argument
     /// [`ArgSettings`]: ./enum.ArgSettings.html
@@ -3730,10 +3733,14 @@ impl<'a, 'b> Arg<'a, 'b> {
     }
 
     #[doc(hidden)]
-    pub fn setb(&mut self, s: ArgSettings) { self.b.set(s); }
+    pub fn setb(&mut self, s: ArgSettings) {
+        self.b.set(s);
+    }
 
     #[doc(hidden)]
-    pub fn unsetb(&mut self, s: ArgSettings) { self.b.unset(s); }
+    pub fn unsetb(&mut self, s: ArgSettings) {
+        self.b.unset(s);
+    }
 }
 
 impl<'a, 'b, 'z> From<&'z Arg<'a, 'b>> for Arg<'a, 'b> {
@@ -3749,5 +3756,7 @@ impl<'a, 'b, 'z> From<&'z Arg<'a, 'b>> for Arg<'a, 'b> {
 }
 
 impl<'n, 'e> PartialEq for Arg<'n, 'e> {
-    fn eq(&self, other: &Arg<'n, 'e>) -> bool { self.b == other.b }
+    fn eq(&self, other: &Arg<'n, 'e>) -> bool {
+        self.b == other.b
+    }
 }

--- a/src/completions/powershell.rs
+++ b/src/completions/powershell.rs
@@ -19,55 +19,37 @@ impl<'a, 'b> PowerShellGen<'a, 'b> {
         let bin_name = self.p.meta.bin_name.as_ref().unwrap();
 
         let mut names = vec![];
-        let (subcommands_detection_cases, subcommands_cases) =
+        let subcommands_cases =
             generate_inner(self.p, "", &mut names);
 
-        let mut bin_names = vec![bin_name.to_string(), format!("./{0}", bin_name)];
-        if cfg!(windows) {
-            bin_names.push(format!("{0}.exe", bin_name));
-            bin_names.push(format!(r".\{0}", bin_name));
-            bin_names.push(format!(r".\{0}.exe", bin_name));
-            bin_names.push(format!(r"./{0}.exe", bin_name));
-        }
-
-        let bin_names = bin_names.iter().fold(String::new(), |previous, current| {
-            format!("{0}, '{1}'", previous, current)
-        });
-        let bin_names = bin_names.trim_left_matches(", ");
-
         let result = format!(r#"
-@({bin_names}) | %{{
-    Register-ArgumentCompleter -Native -CommandName $_ -ScriptBlock {{
-        param($wordToComplete, $commandAst, $cursorPosition)
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
 
-        $command = '_{bin_name}'
-        $commandAst.CommandElements |
-            Select-Object -Skip 1 |
-            %{{
-                switch ($_.ToString()) {{
-{subcommands_detection_cases}
-                    default {{ 
-                        break
-                    }}
-                }}
-            }}
+Register-ArgumentCompleter -Native -CommandName '{bin_name}' -ScriptBlock {{
+    param($wordToComplete, $commandAst, $cursorPosition)
 
-        $completions = @()
-
-        switch ($command) {{
-{subcommands_cases}
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        '{bin_name}'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {{
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-')) {{
+                break
         }}
+        $element.Value
+    }}) -join ';'
 
-        $completions |
-            ?{{ $_ -like "$wordToComplete*" }} |
-            Sort-Object |
-            %{{ New-Object System.Management.Automation.CompletionResult $_, $_, 'ParameterValue', $_ }}
-    }}
+    $completions = @(switch ($command) {{{subcommands_cases}
+    }})
+
+    $completions.Where{{ $_.CompletionText -like "$wordToComplete*" }} |
+        Sort-Object -Property ListItemText
 }}
 "#,
-            bin_names = bin_names,
             bin_name = bin_name,
-            subcommands_detection_cases = subcommands_detection_cases,
             subcommands_cases = subcommands_cases
         );
 
@@ -75,64 +57,83 @@ impl<'a, 'b> PowerShellGen<'a, 'b> {
     }
 }
 
+// Escape string inside single quotes
+fn escape_string(string: &str) -> String { string.replace("'", "''") }
+
+fn get_tooltip<T : ToString>(help: Option<&str>, data: T) -> String {
+    match help {
+        Some(help) => escape_string(&help),
+        _ => data.to_string()
+    }
+}
+
 fn generate_inner<'a, 'b, 'p>(
     p: &'p Parser<'a, 'b>,
     previous_command_name: &str,
     names: &mut Vec<&'p str>,
-) -> (String, String) {
+) -> String {
     debugln!("PowerShellGen::generate_inner;");
     let command_name = if previous_command_name.is_empty() {
-        format!(
-            "{}_{}",
-            previous_command_name,
-            &p.meta.bin_name.as_ref().expect(INTERNAL_ERROR_MSG)
-        )
+        p.meta.bin_name.as_ref().expect(INTERNAL_ERROR_MSG).clone()
     } else {
-        format!("{}_{}", previous_command_name, &p.meta.name)
-    };
-
-    let mut subcommands_detection_cases = if !names.contains(&&*p.meta.name) {
-        names.push(&*p.meta.name);
-        format!(
-            r"
-                    '{0}' {{
-                        $command += '_{0}'
-                        break
-                    }}
-",
-            &p.meta.name
-        )
-    } else {
-        String::new()
+        format!("{};{}", previous_command_name, &p.meta.name)
     };
 
     let mut completions = String::new();
+    let preamble = String::from("\n            [CompletionResult]::new(");
+
+    for option in p.opts() {
+        if let Some(data) = option.s.short {
+            let tooltip = get_tooltip(option.b.help, data);
+            completions.push_str(&preamble);
+            completions.push_str(format!("'-{}', '{}', {}, '{}')",
+                                         data, data, "[CompletionResultType]::ParameterName", tooltip).as_str());
+        }
+        if let Some(data) = option.s.long {
+            let tooltip = get_tooltip(option.b.help, data);
+            completions.push_str(&preamble);
+            completions.push_str(format!("'--{}', '{}', {}, '{}')",
+                                         data, data, "[CompletionResultType]::ParameterName", tooltip).as_str());
+        }
+    }
+
+    for flag in p.flags() {
+        if let Some(data) = flag.s.short {
+            let tooltip = get_tooltip(flag.b.help, data);
+            completions.push_str(&preamble);
+            completions.push_str(format!("'-{}', '{}', {}, '{}')",
+                                         data, data, "[CompletionResultType]::ParameterName", tooltip).as_str());
+        }
+        if let Some(data) = flag.s.long {
+            let tooltip = get_tooltip(flag.b.help, data);
+            completions.push_str(&preamble);
+            completions.push_str(format!("'--{}', '{}', {}, '{}')",
+                                         data, data, "[CompletionResultType]::ParameterName", tooltip).as_str());
+        }
+    }
+
     for subcommand in &p.subcommands {
-        completions.push_str(&format!("'{}', ", &subcommand.p.meta.name));
-    }
-    for short in shorts!(p) {
-        completions.push_str(&format!("'-{}', ", short));
-    }
-    for long in longs!(p) {
-        completions.push_str(&format!("'--{}', ", long));
+        let data = &subcommand.p.meta.name;
+        let tooltip = get_tooltip(subcommand.p.meta.about, data);
+        completions.push_str(&preamble);
+        completions.push_str(format!("'{}', '{}', {}, '{}')",
+                                     data, data, "[CompletionResultType]::ParameterValue", tooltip).as_str());
     }
 
     let mut subcommands_cases = format!(
         r"
-            '{}' {{
-                $completions = @({})
-            }}
-",
+        '{}' {{{}
+            break
+        }}",
         &command_name,
-        completions.trim_right_matches(", ")
+        completions
     );
 
     for subcommand in &p.subcommands {
-        let (subcommand_subcommands_detection_cases, subcommand_subcommands_cases) =
+        let subcommand_subcommands_cases =
             generate_inner(&subcommand.p, &command_name, names);
-        subcommands_detection_cases.push_str(&subcommand_subcommands_detection_cases);
         subcommands_cases.push_str(&subcommand_subcommands_cases);
     }
 
-    (subcommands_detection_cases, subcommands_cases)
+    subcommands_cases
 }

--- a/src/osstringext.rs
+++ b/src/osstringext.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 use INVALID_UTF8;
 use std::ffi::OsStr;
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use std::os::unix::ffi::OsStrExt;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 pub trait OsStrExt3 {
     fn from_bytes(b: &[u8]) -> &Self;
     fn as_bytes(&self) -> &[u8];
@@ -22,19 +22,25 @@ pub trait OsStrExt2 {
     fn split(&self, b: u8) -> OsSplit;
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 impl OsStrExt3 for OsStr {
     fn from_bytes(b: &[u8]) -> &Self {
         use std::mem;
         unsafe { mem::transmute(b) }
     }
-    fn as_bytes(&self) -> &[u8] { self.to_str().map(|s| s.as_bytes()).expect(INVALID_UTF8) }
+    fn as_bytes(&self) -> &[u8] {
+        self.to_str().map(|s| s.as_bytes()).expect(INVALID_UTF8)
+    }
 }
 
 impl OsStrExt2 for OsStr {
-    fn starts_with(&self, s: &[u8]) -> bool { self.as_bytes().starts_with(s) }
+    fn starts_with(&self, s: &[u8]) -> bool {
+        self.as_bytes().starts_with(s)
+    }
 
-    fn is_empty_(&self) -> bool { self.as_bytes().is_empty() }
+    fn is_empty_(&self) -> bool {
+        self.as_bytes().is_empty()
+    }
 
     fn contains_byte(&self, byte: u8) -> bool {
         for b in self.as_bytes() {
@@ -82,7 +88,9 @@ impl OsStrExt2 for OsStr {
         )
     }
 
-    fn len_(&self) -> usize { self.as_bytes().len() }
+    fn len_(&self) -> usize {
+        self.as_bytes().len()
+    }
 
     fn split(&self, b: u8) -> OsSplit {
         OsSplit {


### PR DESCRIPTION
Relates to #1132 

At the suggestion of @kbknapp, I have switched wasm32 targets to use OsStrExt3 (used on Windows). This removes all compile errors on nightly when targeting `wasm32-unknown-unknown`. Additionally, it seems that I ran rustfmt on the source while I was editing, sorry for the extra noise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1187)
<!-- Reviewable:end -->
