### PR TITLE
docs(CONTRIBUTING.md): fix url to clippy upstream repo to point to rust-lang-nursery/rust-clippy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ $ just run-test <test_name>
 
 ### Linting Code
 
-During the CI process `clap` runs against many different lints using [`clippy`](https://github.com/Manishearth/rust-clippy). In order to check if these lints pass on your own computer prior to submitting a PR you'll need a nightly compiler.
+During the CI process `clap` runs against many different lints using [`clippy`](https://github.com/rust-lang-nursery/rust-clippy). In order to check if these lints pass on your own computer prior to submitting a PR you'll need a nightly compiler.
 
 In order to check the code for lints run either:
 


### PR DESCRIPTION
https://github.com/Manishearth/rust-clippy => https://github.com/rust-lang-nursery/rust-clippy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1193)
<!-- Reviewable:end -->
