### PR TITLE
bump version on term size to 1.0.0-beta1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }
-term_size = { version = "0.3.0", optional = true }
+term_size = { version = "1.0.0-beta1", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 ansi_term = { version = "0.10.0",  optional = true }


### PR DESCRIPTION
As part of v3, @kbknapp would like to depend on term_size 1.0 instead of 0.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1202)
<!-- Reviewable:end -->
