### PR TITLE
Disable typo suggestions in presence of external subcommands

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -976,7 +976,7 @@ where
             }
 
             if !(self.is_set(AS::ArgsNegateSubcommands) && self.is_set(AS::ValidArgFound))
-                && !self.is_set(AS::InferSubcommands)
+                && !self.is_set(AS::InferSubcommands) && !self.is_set(AS::AllowExternalSubcommands)
             {
                 if let Some(cdate) =
                     suggestions::did_you_mean(&*arg_os.to_string_lossy(), sc_names!(self))
@@ -994,7 +994,7 @@ where
             let low_index_mults = self.is_set(AS::LowIndexMultiplePositional)
                 && pos_counter == (self.positionals.len() - 1);
             let missing_pos = self.is_set(AS::AllowMissingPositional)
-                && (pos_counter == (self.positionals.len() - 1) 
+                && (pos_counter == (self.positionals.len() - 1)
                     && !self.is_set(AS::TrailingValues));
             debugln!(
                 "Parser::get_matches_with: Positional counter...{}",

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -717,7 +717,7 @@ fn missing_positional_hyphen_req_error() {
 #[test]
 fn issue_1066_allow_leading_hyphen_and_unknown_args() {
     let res = App::new("prog")
-        .global_setting(AppSettings::AllowLeadingHyphen) 
+        .global_setting(AppSettings::AllowLeadingHyphen)
         .arg(Arg::from_usage("--some-argument"))
         .get_matches_from_safe(vec!["prog", "hello"]);
 
@@ -728,7 +728,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args() {
 #[test]
 fn issue_1066_allow_leading_hyphen_and_unknown_args_no_vals() {
     let res = App::new("prog")
-        .global_setting(AppSettings::AllowLeadingHyphen) 
+        .global_setting(AppSettings::AllowLeadingHyphen)
         .arg(Arg::from_usage("--some-argument"))
         .get_matches_from_safe(vec!["prog", "--hello"]);
 
@@ -739,7 +739,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args_no_vals() {
 #[test]
 fn issue_1066_allow_leading_hyphen_and_unknown_args_option() {
     let res = App::new("prog")
-        .global_setting(AppSettings::AllowLeadingHyphen) 
+        .global_setting(AppSettings::AllowLeadingHyphen)
         .arg(Arg::from_usage("--some-argument=[val]"))
         .get_matches_from_safe(vec!["prog", "-hello"]);
 
@@ -753,6 +753,24 @@ fn issue_1093_allow_ext_sc() {
         .version("v1.4.8")
         .setting(AppSettings::AllowExternalSubcommands);
     assert!(test::compare_output(app, "clap-test --help", ALLOW_EXT_SC, false));
+}
+
+#[test]
+fn external_subcommand_looks_like_built_in() {
+    let res = App::new("cargo")
+        .version("1.26.0")
+        .setting(AppSettings::AllowExternalSubcommands)
+        .subcommand(SubCommand::with_name("install"))
+        .get_matches_from_safe(vec!["cargo", "install-update", "foo"]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    match m.subcommand() {
+        (name, Some(args)) => {
+            assert_eq!(name, "install-update");
+            assert_eq!(args.values_of_lossy(""), Some(vec!["foo".to_string()]));
+        }
+        _ => assert!(false),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fix for https://github.com/rust-lang/cargo/issues/5201 =P

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1215)
<!-- Reviewable:end -->
