### PR TITLE
Allow deprecated to remove warnings for rustc 1.26 onwards

### DIFF
--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -1,5 +1,5 @@
 // Std
-#[allow(unused_imports)]
+#[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
 use std::str::FromStr;
 use std::ops::BitOr;

--- a/src/app/validator.rs
+++ b/src/app/validator.rs
@@ -1,6 +1,6 @@
 // std
 use std::fmt::Display;
-#[allow(unused_imports)]
+#[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
 
 // Internal

--- a/src/args/settings.rs
+++ b/src/args/settings.rs
@@ -1,5 +1,5 @@
 // Std
-#[allow(unused_imports)]
+#[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
 use std::str::FromStr;
 

--- a/src/completions/shell.rs
+++ b/src/completions/shell.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+#[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
 use std::str::FromStr;
 use std::fmt;

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -1,6 +1,6 @@
 // Std
 use std::io::Write;
-#[allow(unused_imports)]
+#[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
 
 // Internal

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -314,7 +314,7 @@ macro_rules! arg_enum {
             type Err = String;
 
             fn from_str(s: &str) -> ::std::result::Result<Self,Self::Err> {
-                #[allow(unused_imports)]
+                #[allow(deprecated, unused_imports)]
                 use ::std::ascii::AsciiExt;
                 match s {
                     $(stringify!($v) |

--- a/tests/possible_values.rs
+++ b/tests/possible_values.rs
@@ -3,7 +3,7 @@ extern crate regex;
 
 include!("../clap-test.rs");
 
-#[allow(unused_imports)]
+#[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
 
 use clap::{App, Arg, ErrorKind};


### PR DESCRIPTION
Currently using `arg_enum` macro on `nightly` will trigger the following warning:

```bash
use of deprecated item 'std::ascii::AsciiExt': use inherent methods instead
```

This is due to <https://github.com/rust-lang/rust/blob/master/src/libstd/ascii.rs#L55>. Projects will fail to compile on `nightly` if `#![deny(warnings)]` is set.

Resolve by appending `#[allow(deprecated)]` to affected parts to prevent warnings from bubbling up to the projects using the library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1242)
<!-- Reviewable:end -->
