### PR TITLE
imp: make Arg::validator more flexible (v3)

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -1830,11 +1830,11 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     /// [`Err(String)`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
-    pub fn validator<F>(mut self, f: F) -> Self
-    where
-        F: Fn(String) -> Result<(), String> + 'static,
+    pub fn validator<F, O, E>(mut self, f: F) -> Self
+        where F: Fn(String) -> Result<O, E> + 'static,
+              E: ToString
     {
-        self.validator = Some(Rc::new(f));
+        self.validator = Some(Rc::new(move |s| f(s).map(|_| ()).map_err(|e| e.to_string())));
         self
     }
 
@@ -1868,11 +1868,10 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     /// [`Err(String)`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
-    pub fn validator_os<F>(mut self, f: F) -> Self
-    where
-        F: Fn(&OsStr) -> Result<(), OsString> + 'static,
+    pub fn validator_os<F, O>(mut self, f: F) -> Self
+        where F: Fn(&OsStr) -> Result<O, OsString> + 'static
     {
-        self.validator_os = Some(Rc::new(f));
+        self.validator_os = Some(Rc::new(move |s| f(s).map(|_| ())));
         self
     }
 

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -241,6 +241,21 @@ fn validator() {
 }
 
 #[test]
+fn validator_output() {
+    env::set_var("CLP_TEST_ENV", "42");
+
+    let r = App::new("df")
+        .arg(
+            Arg::from_usage("[arg] 'some opt'")
+                .env("CLP_TEST_ENV")
+                .validator(|s| s.parse::<i32>())
+        )
+        .get_matches_from_safe(vec![""]);
+
+    assert_eq!(r.unwrap().value_of("arg").unwrap().parse(), Ok(42));
+}
+
+#[test]
 fn validator_invalid() {
     env::set_var("CLP_TEST_ENV", "env");
 


### PR DESCRIPTION
From #1088.

Makes the validator functions more flexible by changing the return type from `Result<(), String>` to `Result<O, E>` where `O` is anything and `E` is anything convertible to a `String`.

This allows, for example, using the same function for validating and parsing your argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1243)
<!-- Reviewable:end -->
