### PR TITLE
Remove unused or unnecessary methods from osstringext

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -809,7 +809,7 @@ where
         // Is this a new argument, or values from a previous option?
         let mut ret = if arg_os.starts_with(b"--") {
             debugln!("Parser::is_new_arg: -- found");
-            if arg_os.len_() == 2 && !arg_allows_tac {
+            if arg_os.len() == 2 && !arg_allows_tac {
                 return true; // We have to return true so override everything else
             } else if arg_allows_tac {
                 return false;
@@ -818,7 +818,7 @@ where
         } else if arg_os.starts_with(b"-") {
             debugln!("Parser::is_new_arg: - found");
             // a singe '-' by itself is a value and typically means "stdin" on unix systems
-            !(arg_os.len_() == 1)
+            !(arg_os.len() == 1)
         } else {
             debugln!("Parser::is_new_arg: probably value");
             false
@@ -874,7 +874,7 @@ where
             self.unset(AS::ValidNegNumFound);
             // Is this a new argument, or values from a previous option?
             let starts_new_arg = self.is_new_arg(&arg_os, needs_val_of);
-            if !self.is_set(AS::TrailingValues) && arg_os.starts_with(b"--") && arg_os.len_() == 2
+            if !self.is_set(AS::TrailingValues) && arg_os.starts_with(b"--") && arg_os.len() == 2
                 && starts_new_arg
             {
                 debugln!("Parser::get_matches_with: setting TrailingVals=true");
@@ -931,7 +931,7 @@ where
                             }
                             _ => (),
                         }
-                    } else if arg_os.starts_with(b"-") && arg_os.len_() != 1 {
+                    } else if arg_os.starts_with(b"-") && arg_os.len() != 1 {
                         // Try to parse short args like normal, if AllowLeadingHyphen or
                         // AllowNegativeNumbers is set, parse_short_arg will *not* throw
                         // an error, and instead return Ok(None)
@@ -1724,7 +1724,7 @@ where
         if let Some(fv) = val {
             has_eq = fv.starts_with(&[b'=']) || had_eq;
             let v = fv.trim_left_matches(b'=');
-            if !empty_vals && (v.len_() == 0 || (needs_eq && !has_eq)) {
+            if !empty_vals && (v.len() == 0 || (needs_eq && !has_eq)) {
                 sdebugln!("Found Empty - Error");
                 return Err(Error::empty_value(
                     opt,
@@ -1732,7 +1732,7 @@ where
                     self.color(),
                 ));
             }
-            sdebugln!("Found - {:?}, len: {}", v, v.len_());
+            sdebugln!("Found - {:?}, len: {}", v, v.len());
             debugln!(
                 "Parser::parse_opt: {:?} contains '='...{:?}",
                 fv,
@@ -1785,7 +1785,7 @@ where
         );
         if !(self.is_set(AS::TrailingValues) && self.is_set(AS::DontDelimitTrailingValues)) {
             if let Some(delim) = arg.val_delim() {
-                if val.is_empty_() {
+                if val.is_empty() {
                     Ok(self.add_single_val_to_arg(arg, val, matcher)?)
                 } else {
                     let mut iret = ParseResult::ValuesDone;

--- a/src/app/validator.rs
+++ b/src/app/validator.rs
@@ -10,7 +10,6 @@ use args::{AnyArg, ArgMatcher, MatchedArg};
 use args::settings::ArgSettings;
 use errors::{Error, ErrorKind};
 use errors::Result as ClapResult;
-use osstringext::OsStrExt2;
 use app::settings::AppSettings as AS;
 use app::parser::{ParseResult, Parser};
 use fmt::{Colorizer, ColorizerOption};
@@ -120,7 +119,7 @@ impl<'a, 'b, 'z> Validator<'a, 'b, 'z> {
                     ));
                 }
             }
-            if !arg.is_set(ArgSettings::EmptyValues) && val.is_empty_()
+            if !arg.is_set(ArgSettings::EmptyValues) && val.is_empty()
                 && matcher.contains(&*arg.name())
             {
                 debugln!("Validator::validate_arg_values: illegal empty val found");

--- a/src/osstringext.rs
+++ b/src/osstringext.rs
@@ -16,9 +16,7 @@ pub trait OsStrExt2 {
     fn split_at_byte(&self, b: u8) -> (&OsStr, &OsStr);
     fn split_at(&self, i: usize) -> (&OsStr, &OsStr);
     fn trim_left_matches(&self, b: u8) -> &OsStr;
-    fn len_(&self) -> usize;
     fn contains_byte(&self, b: u8) -> bool;
-    fn is_empty_(&self) -> bool;
     fn split(&self, b: u8) -> OsSplit;
 }
 
@@ -36,10 +34,6 @@ impl OsStrExt3 for OsStr {
 impl OsStrExt2 for OsStr {
     fn starts_with(&self, s: &[u8]) -> bool {
         self.as_bytes().starts_with(s)
-    }
-
-    fn is_empty_(&self) -> bool {
-        self.as_bytes().is_empty()
     }
 
     fn contains_byte(&self, byte: u8) -> bool {
@@ -62,7 +56,7 @@ impl OsStrExt2 for OsStr {
         }
         (
             &*self,
-            OsStr::from_bytes(&self.as_bytes()[self.len_()..self.len_()]),
+            OsStr::from_bytes(&self.as_bytes()[self.len()..self.len()]),
         )
     }
 
@@ -76,7 +70,7 @@ impl OsStrExt2 for OsStr {
             }
         }
         if found {
-            return OsStr::from_bytes(&self.as_bytes()[self.len_()..]);
+            return OsStr::from_bytes(&self.as_bytes()[self.len()..]);
         }
         &*self
     }
@@ -86,10 +80,6 @@ impl OsStrExt2 for OsStr {
             OsStr::from_bytes(&self.as_bytes()[..i]),
             OsStr::from_bytes(&self.as_bytes()[i..]),
         )
-    }
-
-    fn len_(&self) -> usize {
-        self.as_bytes().len()
     }
 
     fn split(&self, b: u8) -> OsSplit {
@@ -125,33 +115,5 @@ impl<'a> Iterator for OsSplit<'a> {
             }
         }
         Some(OsStr::from_bytes(&self.val[start..]))
-    }
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut count = 0;
-        for b in &self.val[self.pos..] {
-            if *b == self.sep {
-                count += 1;
-            }
-        }
-        if count > 0 {
-            return (count, Some(count));
-        }
-        (0, None)
-    }
-}
-
-impl<'a> DoubleEndedIterator for OsSplit<'a> {
-    fn next_back(&mut self) -> Option<&'a OsStr> {
-        if self.pos == 0 {
-            return None;
-        }
-        let start = self.pos;
-        for b in self.val[..self.pos].iter().rev() {
-            self.pos -= 1;
-            if *b == self.sep {
-                return Some(OsStr::from_bytes(&self.val[self.pos + 1..start]));
-            }
-        }
-        Some(OsStr::from_bytes(&self.val[..start]))
     }
 }


### PR DESCRIPTION
* `OsStr` gained `.len()` and `.is_empty()` in Rust 1.6, so remove `.len_()` and `.is_empty_()`
* `Split`'s `DoubleEndedIterator` implementation is completely wrong and unused
  (moves a cursor backward instead of splitting from the end)
* `Split`'s `.size_hint()` is slightly wrong and unused
  (produces (0,None) instead of (0,Some(0)) when empty, and is O(n))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1247)
<!-- Reviewable:end -->
