### PR TITLE
Enable help dialogs alongside default values

### DIFF
--- a/src/app/validator.rs
+++ b/src/app/validator.rs
@@ -60,7 +60,7 @@ impl<'a, 'b, 'z> Validator<'a, 'b, 'z> {
             }
         }
 
-        if matcher.is_empty() && matcher.subcommand_name().is_none()
+        if !reqs_validated && matcher.subcommand_name().is_none()
             && self.0.is_set(AS::ArgRequiredElseHelp)
         {
             let mut out = vec![];


### PR DESCRIPTION
This should fix #1264. It appears to correct the issue and all tests pass with `cargo test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1265)
<!-- Reviewable:end -->
