### PR TITLE
Include guards around os-specific string elements.

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -3,8 +3,10 @@ use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
-#[cfg(all(feature = "debug", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "debug", not(any(target_os = "windows", target_arch = "wasm32"))))]
 use std::os::unix::ffi::OsStrExt;
+#[cfg(all(feature = "debug", any(target_os = "windows", target_arch = "wasm32")))]
+use osstringext::OsStrExt3;
 use std::path::PathBuf;
 use std::slice::Iter;
 use std::iter::Peekable;


### PR DESCRIPTION
This seems to be something missed some time ago as the original annotation for this 'use' was only feature debug. However this broke builds using that feature on Windows for a while.

This change uses guards both for the feature and also wasm/windows specific targets/environments.
These guards are the same as are currently in use for Windows/wasm in [parser.rs](https://github.com/kbknapp/clap-rs/blob/dc7ae65fb784dc355d56f09554f1216b22755c3e/src/app/parser.rs#L659)

closes #1270 and is done in response to Drops-of-Diamond/diamond_drops#59

fyi: @jamesray1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1271)
<!-- Reviewable:end -->
