### PR TITLE
chore: increases the minimum required rustc to 1.21.0 due to sub-sub-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly-2017-10-11
   - beta
   - stable
-  - 1.20.0
+  - 1.21.0
 matrix:
     allow_failures:
         - rust: nightly


### PR DESCRIPTION
…sub deps increasing their minimum rustc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1275)
<!-- Reviewable:end -->
