### PR TITLE
fix(OsValues): Add `ExactSizeIterator` implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: rust
 cache: cargo
 rust:
   - nightly
-  - nightly-2017-10-11
+  - nightly-2018-06-19
   - beta
   - stable
   - 1.21.0

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -855,6 +855,8 @@ impl<'a> DoubleEndedIterator for OsValues<'a> {
     fn next_back(&mut self) -> Option<&'a OsStr> { self.iter.next_back() }
 }
 
+impl<'a> ExactSizeIterator for OsValues<'a> {}
+
 /// Creates an empty iterator.
 impl<'a> Default for OsValues<'a> {
     fn default() -> Self {


### PR DESCRIPTION
It seems like an oversight that this was omitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1301)
<!-- Reviewable:end -->
