### PR TITLE
fix typo in example 04_using_matches.rs

### DIFF
--- a/examples/04_using_matches.rs
+++ b/examples/04_using_matches.rs
@@ -40,8 +40,8 @@ fn main() {
         println!("Debugging is turned on");
     }
 
-    // If we wanted to some custom initialization based off some configuration file provided
-    // by the user, we could get the file (A string of the file)
+    // If we wanted to do some custom initialization based off some configuration file
+    // provided by the user, we could get the file (A string of the file)
     if let Some(file) = matches.value_of("config") {
         println!("Using config file: {}", file);
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1319)
<!-- Reviewable:end -->
